### PR TITLE
Unify logging for link clicks and page views

### DIFF
--- a/static/js/statsig_docs.js
+++ b/static/js/statsig_docs.js
@@ -5,8 +5,8 @@ function wireClickHandlers(tagName) {
     el.addEventListener('click', () => {
       statsig.logEvent(
         'link_click', 
-        el.href, 
-        { page : window.location.href }
+        el.pathname, 
+        { page : window.location.href, referrer: document && document.referrer }
       );
     });
   }
@@ -20,8 +20,8 @@ function initStatsig() {
   ).then((err) => {
     statsig.logEvent(
       'page_view', 
-      window.location.href, 
-      { referrer: document && document.referrer }
+      window.location.pathname, 
+      { page : window.location.href, referrer: document && document.referrer }
     );
   });
 }


### PR DESCRIPTION
We were logging pathname in some cases: https://github.com/statsig-io/docs/blob/main/statsig.js#L11
 and the full href in others.  We dont need the full href, just the pathname is sufficient (and this way we wont log url params that are not necessary).  Its cleaner to aggregate by the pathname than the full href