### PR TITLE
Flatten Feature Gates heirarchy

### DIFF
--- a/docs/feature-gates/working-with.md
+++ b/docs/feature-gates/working-with.md
@@ -1,10 +1,16 @@
 ---
-title: Working with feature gates
+title: What is a feature gate?
 sidebar_label: Overview
 slug: /feature-gates/working-with
 ---
 
-Statsig offers several built-in capabilities with feature gate:
+A feature gate is a mechanism for teams to configure what system behavior is visible to users without changing application code. Feature gates are also commonly called feature flags or feature toggles.
+
+## When to use feature gates
+
+Feature gates are commonly used as on/off switches to turn a certain system behavior on or off in production. Teams often use feature gates to turn on certain features or behavior for a small percentage of the total user base. Teams may do this to gradually ramp up a software release across their user base to limit the impact of any unanticipated system behavior, or to enable a restricted behavior only for a specific set of users.
+
+Statsig offers several built-in capabilities with feature gates:
 
 - A feature gate can be a simple _kill switch_ that you can use to turn off a particular code branch for all your users
 - You can use a feature gate to target newly coded system behavior to a specific set of users to implement _whitelisting_

--- a/sidebars.js
+++ b/sidebars.js
@@ -20,27 +20,22 @@ module.exports = {
     },
     {
       "Feature Gates": [
-        "feature-gates/introduction",
+        "feature-gates/working-with",
+        "feature-gates/create-new",
+        "feature-gates/add-rule",
+        "feature-gates/test-gate",
+        "feature-gates/overrides",
         {
-          "Working With": [
-            "feature-gates/working-with",
-            "feature-gates/create-new",
-            "feature-gates/add-rule",
-            "feature-gates/test-gate",
-            "feature-gates/overrides",
-            {
-              Implement: [
-                "feature-gates/implement",
-                "feature-gates/implement/client",
-                "feature-gates/implement/server",
-                "feature-gates/implement/http-api",
-              ],
-            },
-            "feature-gates/conditions",
-            "feature-gates/view-exposures",
-            "feature-gates/best-practices",
+          Implement: [
+            "feature-gates/implement",
+            "feature-gates/implement/client",
+            "feature-gates/implement/server",
+            "feature-gates/implement/http-api",
           ],
         },
+        "feature-gates/conditions",
+        "feature-gates/view-exposures",
+        "feature-gates/best-practices",
       ],
     },
     {


### PR DESCRIPTION
This change flattens the heirarchy of the Feature Gates docs section, and removes the previous introduction page.

## Before
Introduction page has confusing set of links to previous section:
![Screen Shot 2022-02-25 at 11 05 05 AM](https://user-images.githubusercontent.com/100379722/155773672-2ba62959-d201-4188-88ea-0fad452a39d8.png)

Feature gates menu has somewhat unecessary "Working With folder" with only Introduction outside it.
![Screen Shot 2022-02-25 at 10 51 51 AM](https://user-images.githubusercontent.com/100379722/155773850-12b87e4b-7dfb-415b-84f0-95022ce0910a.png)

## After
Overview Page now has content from old Introduction page, except for links to previous section. Introduction page and "Working With" folder are gone, heirarchy is now flat.
![Screen Shot 2022-02-25 at 11 02 00 AM](https://user-images.githubusercontent.com/100379722/155773930-fd9305fe-d059-40be-95ba-01cbe588f54e.png)

