### PR TITLE
Fixing Ultrasound product card deeplink

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -326,7 +326,7 @@ application:
     title="Ultrasound"
     icon="donut_small"
     description="View all experiments that have impacted a metric"
-    link="/console/ultrasound"
+    link="/ultrasound"
   ></OutlinedCard>
   <OutlinedCard
     title="Holdouts"


### PR DESCRIPTION
from /console/ultrasound to /ultrasound