### PR TITLE
Fix typo in Python's set_environment_parameter

### DIFF
--- a/docs/server/python/_options.mdx
+++ b/docs/server/python/_options.mdx
@@ -35,6 +35,6 @@ You can also use the `set_environment_parameter` function, but that takes in str
 from statsig import statsig, StatsigEnvironmentTier, StatsigOptions
 
 options = StatsigOptions()
-options.set_evironment_parameter("tier", StatsigEnvironmentTier.development.value)
+options.set_environment_parameter("tier", StatsigEnvironmentTier.development.value)
 statsig.initialize("secret-key", options)
 ```


### PR DESCRIPTION
s/set_evironment_parameter/set_environment_parameter