### PR TITLE
Remove references to "aa" which mess up search for A/A tests

### DIFF
--- a/docs/data-warehouse-ingestion/snowflake.mdx
+++ b/docs/data-warehouse-ingestion/snowflake.mdx
@@ -20,7 +20,7 @@ Admin user name and password will be used by Statsig to create a user with restr
 
 For the Account Name field, please enter in the format of `<id>.<region>.<provider>`. So, your information may look something like this:
 
-`aa00000.us-central1.gcp`
+`xy12345.us-central1.gcp`
 
 To get this information navigate to bottom left in your Snowflake console, as shown in the picture below and copy the link URL:
 

--- a/docs/integrations/data-imports/snowflake-deprecated.md
+++ b/docs/integrations/data-imports/snowflake-deprecated.md
@@ -153,15 +153,15 @@ The user object is a stringified JSON representation. An example might look like
   "ip": "1.1.1.1",
   "country": "KR",
   "locale": "en-US",
-  "userID": "aaaaa-aaaaa-aaaaa-aaaaa",
+  "userID": "bbbbb-bbbbb-bbbbb-bbbbb",
   "custom": {
     "locale": "en-US",
     "clientVersion": "23.10.23.10",
     "desktopVersion": "11.5.0"
   },
   "customIDs": {
-    "deviceId": "aaaaa-aaaaa-aaaaa-aaaaa",
-    "stableID": "aaaaa-aaaaa-aaaaa-aaaaa"
+    "deviceId": "ddddd-ddddd-ddddd-ddddd",
+    "stableID": "sssss-sssss-sssss-sssss"
   }
 }
 ```

--- a/docs/integrations/snippets/integration_event_formats.mdx
+++ b/docs/integrations/snippets/integration_event_formats.mdx
@@ -35,7 +35,7 @@ Events will be sent in batches in a JSON format. The structure of a Statsig Even
     "key_a": "value_a",
     "key_b": "123"
   },
-  "timeUUID": "aad2a983-ec0f-11ec-917a-fb8cdaeda578"
+  "timeUUID": "abd2a983-ec0f-11ec-917a-fb8cdaeda578"
 }
 ```
 
@@ -146,7 +146,7 @@ Events will be sent in batches in a JSON format. The structure of a Statsig Even
     "value": "example_value",
     "metadata": {"page": "home_page"},
     "statsigMetadata": {},
-    "timeUUID": "f4c414a0-8aa5-11ec-a8a3-0242ac120002"
+    "timeUUID": "f4c414a0-8ab5-11ec-a8a3-0242ac120002"
   },
   {
     "eventName": "statsig::gate_exposure",
@@ -156,7 +156,7 @@ Events will be sent in batches in a JSON format. The structure of a Statsig Even
     "value": "",
     "metadata": {"gate": "test_gate", "gateValue": "true", "ruleID": "default"},
     "statsigMetadata": {},
-    "timeUUID": "f4c414a0-8aa5-11ec-a8a3-0242ac120003",
+    "timeUUID": "f4c414a0-8ab5-11ec-a8a3-0242ac120003",
     "unitID": "userID"
   },
   {
@@ -169,7 +169,7 @@ Events will be sent in batches in a JSON format. The structure of a Statsig Even
        "config": "an_experiment", "ruleID": "4SauZJcM1T7zNvh1igBjwE", "reason": "Network", "time": "1655231249644", "experimentGroupName": "Control"
     },
     "statsigMetadata": {},
-    "timeUUID": "f4c414a0-8aa5-11ec-a8a3-0242ac120004",
+    "timeUUID": "f4c414a0-8ab5-11ec-a8a3-0242ac120004",
     "unitID": "userID"
   }
 ]


### PR DESCRIPTION
This fixes the following issue with search for an "aa" test

![image](https://user-images.githubusercontent.com/77478319/231558861-3af8ebd4-3af3-4108-9a70-7be4bc59638a.png)
