### PR TITLE
Update Console API URLs

### DIFF
--- a/docs/console-api/openapi/all-endpoints.js
+++ b/docs/console-api/openapi/all-endpoints.js
@@ -4,7 +4,7 @@ module.exports = {
     "id": "85s9baacsp738"
   },
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0.0"
   },
   "servers": [

--- a/docs/console-api/openapi/audit-logs.js
+++ b/docs/console-api/openapi/audit-logs.js
@@ -1,7 +1,7 @@
 module.exports = {
   "openapi": "3.0.0",
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0.0"
   },
   "servers": [

--- a/docs/console-api/openapi/autotunes.js
+++ b/docs/console-api/openapi/autotunes.js
@@ -4,7 +4,7 @@ module.exports = {
     "id": "95941d9430eba"
   },
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0.0"
   },
   "servers": [

--- a/docs/console-api/openapi/dynamic-configs.js
+++ b/docs/console-api/openapi/dynamic-configs.js
@@ -1,7 +1,7 @@
 module.exports = {
   "openapi": "3.0.0",
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0.0"
   },
   "servers": [

--- a/docs/console-api/openapi/experiments.js
+++ b/docs/console-api/openapi/experiments.js
@@ -4,7 +4,7 @@ module.exports = {
     "id": "e0352ead0cc67"
   },
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0.0",
     "description": "Experiment endpoint"
   },

--- a/docs/console-api/openapi/gates.js
+++ b/docs/console-api/openapi/gates.js
@@ -1,7 +1,7 @@
 module.exports = {
   "openapi": "3.0.0",
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0.0"
   },
   "servers": [

--- a/docs/console-api/openapi/holdouts.js
+++ b/docs/console-api/openapi/holdouts.js
@@ -1,7 +1,7 @@
 module.exports = {
   "openapi": "3.0.0",
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0.0"
   },
   "servers": [

--- a/docs/console-api/openapi/layers.js
+++ b/docs/console-api/openapi/layers.js
@@ -1,7 +1,7 @@
 module.exports = {
   "openapi": "3.0.0",
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0.0",
     "description": "Layer endpoint"
   },

--- a/docs/console-api/openapi/metrics.js
+++ b/docs/console-api/openapi/metrics.js
@@ -4,7 +4,7 @@ module.exports = {
     "id": "gxm032r7wg95q"
   },
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0",
     "description": "Metrics Endpoint"
   },

--- a/docs/console-api/openapi/reports.js
+++ b/docs/console-api/openapi/reports.js
@@ -4,7 +4,7 @@ module.exports = {
     "id": "tbgqir4m41g7b"
   },
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0",
   },
   "servers": [

--- a/docs/console-api/openapi/segments.js
+++ b/docs/console-api/openapi/segments.js
@@ -1,7 +1,7 @@
 module.exports = {
   "openapi": "3.0.0",
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0.0"
   },
   "servers": [

--- a/docs/console-api/openapi/usage-billing.js
+++ b/docs/console-api/openapi/usage-billing.js
@@ -4,7 +4,7 @@ module.exports = {
     "id": "lkjxksvkisn4a"
   },
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0.0"
   },
   "servers": [

--- a/docs/console-api/openapi/users.js
+++ b/docs/console-api/openapi/users.js
@@ -4,7 +4,7 @@ module.exports = {
     "id": "0f7f8wu4j7re3"
   },
   "info": {
-    "title": "console/v1",
+    "title": "https://statsigapi.net/console/v1",
     "version": "1.0",
     "description": "Users Endpoint"
   },


### PR DESCRIPTION
Be more explicit with title and include the full URL instead of just `console/v1`.
