### PR TITLE
Replace references to deprecated async methods

### DIFF
--- a/docs/feature-gates/implement/server.mdx
+++ b/docs/feature-gates/implement/server.mdx
@@ -203,7 +203,7 @@ const user = {
   ...
 };
 
-const showNewDesign = await statsig.checkGate(user, 'FEATURE_GATE_NAME');
+const showNewDesign = Statsig.checkGateSync(user, 'FEATURE_GATE_NAME');
 if (showNewDesign) {
   // show new design here
 } else {

--- a/docs/server/node/_checkGate.mdx
+++ b/docs/server/node/_checkGate.mdx
@@ -5,7 +5,7 @@ const user = {
   ...
 };
 
-const showNewDesign = await Statsig.checkGate(user, 'new_homepage_design');
+const showNewDesign = Statsig.checkGateSync(user, 'new_homepage_design');
 if (showNewDesign) {
   // show new design here
 } else {

--- a/docs/server/node/_manualExposures.mdx
+++ b/docs/server/node/_manualExposures.mdx
@@ -6,7 +6,7 @@ export const Snippets = {
   // Gates
   gateSnippet: (
     <CodeBlock language="jsx">
-      {`const result = await Statsig.checkGateWithExposureLoggingDisabled(aUser, 'a_gate_name');`}
+      {`const result = Statsig.checkGateWithExposureLoggingDisabledSync(aUser, 'a_gate_name');`}
     </CodeBlock>
   ),
   gateExposureSnippet: (


### PR DESCRIPTION
These methods are deprecated and shouldn't be referenced