### PR TITLE
Remove SDK helper pages from search in docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -106,15 +106,6 @@ module.exports = {
     },
   },
   plugins: [
-    [
-      require.resolve("@easyops-cn/docusaurus-search-local"),
-      {
-        hashed: true,
-        indexBlog: false,
-        indexDocs: true,
-        docsRouteBasePath: "/",
-      },
-    ],
     function statsig() {
       const isProd = process.env.NODE_ENV === "production";
       const tier = isProd ? "production" : "development";
@@ -215,6 +206,21 @@ module.exports = {
             from: "/integrations/terraform",
           },
         ],
+      },
+    ],
+  ],
+  themes: [
+    [
+      require.resolve("@easyops-cn/docusaurus-search-local"),
+      {
+        hashed: true,
+        indexBlog: false,
+        indexDocs: true,
+        docsRouteBasePath: "/",
+        ignoreFiles: [
+          /client.*/i,
+          /server.*/i,
+        ]
       },
     ],
   ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -218,8 +218,10 @@ module.exports = {
         indexDocs: true,
         docsRouteBasePath: "/",
         ignoreFiles: [
-          /client.*/i,
-          /server.*/i,
+          /client\/_[^\/]*\.mdx/i,
+          /server\/_[^\/]*\.mdx/i,
+          /client\/(Android|AndroidOnDeviceEvaluation|Dart|React|ReactNative|Roku|SwiftOnDeviceEval|Templates|Unity|dotnet|iOS|js|jslocal)\/?/i,
+          /server\/(Templates|java|node|cpp|dotnet|erlang|go|php|python|ruby|rust)\/?/i,
         ]
       },
     ],


### PR DESCRIPTION
This might be over-removing files now - I think each sdk landing page doesnt exist now