### PR TITLE
Fix POST holdout overrides example cURL

### DIFF
--- a/docs/console-api/openapi/snippets/x-code-samples/holdouts.js
+++ b/docs/console-api/openapi/snippets/x-code-samples/holdouts.js
@@ -83,13 +83,16 @@ curl --request DELETE 'https://statsigapi.net/console/v1/holdouts/a_holdout'
         "lang": "cURL",
         "label": "cURL",
         "source": `
-curl --request POST 'https://statsigapi.net/console/v1/holdouts' 
+curl --request POST 'https://statsigapi.net/console/v1/holdouts/a_holdout/overrides' 
 --header 'STATSIG-API-KEY: console-xxxxxXXXXXXXXXxxxxxxxxxXXXXXXXxxxxxxxx' 
 --header 'Content-Type: application/json' 
 --data-raw '{
-    "name": "a holdout",
-    "description": "helpful summary of what this holdout does",
-    "idType": "userID"
+  "passingUserIDs": [
+    "passing_id"
+  ],
+  "failingUserIDs": [
+    "failing_id"
+  ]
 }'
         `
       }


### PR DESCRIPTION
The example cURL for updating overrides was the cURL to create a holdout instead. Copied the sample body / URL from openapi schema instead

(see https://statsigconnect.slack.com/archives/C04KS9DGZRV/p1710430938712809)