### PR TITLE
add id field to rule

### DIFF
--- a/docs/console-api/models/rule.json
+++ b/docs/console-api/models/rule.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "x-stoplight": {
-    "id": "5nanebm76ic8y"
+    "id": "b3wvx0g2u84wt"
   },
   "x-examples": {
     "example-1": {
@@ -20,9 +20,17 @@
       "type": "string",
       "description": "The name of this rule.",
       "x-stoplight": {
-        "id": "81gh8e3wtaon5"
+        "id": "jytmgdw8e7zux"
       },
       "example": "All Conditions"
+    },
+    "id": {
+      "type": "string",
+      "x-stoplight": {
+        "id": "fh8edschydwyl"
+      },
+      "example": "38ttpCpzrQFTMKcqFKk02l",
+      "description": "The Statsig ID of this rule."
     },
     "passPercentage": {
       "type": "integer",
@@ -30,7 +38,7 @@
       "minimum": 0,
       "maximum": 100,
       "x-stoplight": {
-        "id": "v8v6pnj65wgxt"
+        "id": "7q6cwyew01xwj"
       },
       "example": 10
     },
@@ -38,12 +46,12 @@
       "type": "array",
       "description": "An array of Condition objects.",
       "x-stoplight": {
-        "id": "nmnih04emdf1d"
+        "id": "vw9ybs90886bu"
       },
       "items": {
         "$ref": "./condition.json",
         "x-stoplight": {
-          "id": "fclccmgdrz3wg"
+          "id": "5mp6i9ira5jy9"
         }
       }
     },
@@ -51,7 +59,20 @@
       "type": "object",
       "description": "The JSON object returned when this rule is triggered.",
       "x-stoplight": {
-        "id": "9fxgei6rpg9ju"
+        "id": "3ycuq3pkzsrpv"
+      }
+    },
+    "environments": {
+      "type": "array",
+      "x-stoplight": {
+        "id": "u7unbb4bnq7ij"
+      },
+      "description": "The environments this rule is enabled for.",
+      "items": {
+        "x-stoplight": {
+          "id": "t5rruea648bqf"
+        },
+        "type": "string"
       }
     }
   },
@@ -64,6 +85,7 @@
   "examples": [
     {
       "name": "All Conditions",
+      "id": "38ttpCpzrQFTMKcqFKk02l",
       "passPercentage": 10,
       "conditions": [
         {
@@ -76,7 +98,10 @@
       ],
       "returnValue": {
         "key": true
-      }
+      },
+      "environments": [
+        "staging"
+      ]
     }
   ]
 }

--- a/docs/console-api/openapi/dynamic-configs.js
+++ b/docs/console-api/openapi/dynamic-configs.js
@@ -134,6 +134,7 @@ module.exports = {
                         "rules": [
                           {
                             "name": "All Conditions",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 10,
                             "conditions": [
                               {
@@ -177,6 +178,7 @@ module.exports = {
                         "rules": [
                           {
                             "name": "All Conditions",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 10,
                             "conditions": [
                               {
@@ -664,6 +666,7 @@ module.exports = {
                         "rules": [
                           {
                             "name": "All Conditions",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 10,
                             "conditions": [
                               {
@@ -830,6 +833,7 @@ module.exports = {
                         "rules": [
                           {
                             "name": "All Conditions",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 10,
                             "conditions": [
                               {
@@ -987,6 +991,7 @@ module.exports = {
                         "rules": [
                           {
                             "name": "All Conditions",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 10,
                             "conditions": [
                               {
@@ -1030,6 +1035,7 @@ module.exports = {
                         "rules": [
                           {
                             "name": "All Conditions",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 10,
                             "conditions": [
                               {

--- a/docs/console-api/openapi/gates.js
+++ b/docs/console-api/openapi/gates.js
@@ -344,6 +344,7 @@ module.exports = {
                         "rules": [
                           {
                             "name": "Ten percent of users",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 10,
                             "conditions": [
                               {
@@ -507,6 +508,7 @@ module.exports = {
                           "rules": [
                             {
                               "name": "a rule",
+                              "id": "38ttpCpzrQFTMKcqFKk02l",
                               "passPercentage": 100,
                               "conditions": [
                                 {
@@ -520,6 +522,7 @@ module.exports = {
                             },
                             {
                               "name": "ten percent of people",
+                              "id": "38ttpCpzrQFTMKcqFKk02m",
                               "passPercentage": 10,
                               "conditions": [
                                 {
@@ -529,6 +532,7 @@ module.exports = {
                             },
                             {
                               "name": "everyone",
+                              "id": "38ttpCpzrQFTMKcqFKk02n",
                               "passPercentage": 100,
                               "conditions": [
                                 {
@@ -822,6 +826,7 @@ module.exports = {
                         "rules": [
                           {
                             "name": "specific users",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 100,
                             "conditions": [
                               {
@@ -835,6 +840,7 @@ module.exports = {
                           },
                           {
                             "name": "ten percent of people",
+                            "id": "38ttpCpzrQFTMKcqFKk02m",
                             "passPercentage": 10,
                             "conditions": [
                               {
@@ -844,6 +850,7 @@ module.exports = {
                           },
                           {
                             "name": "everyone",
+                            "id": "38ttpCpzrQFTMKcqFKk02n",
                             "passPercentage": 100,
                             "conditions": [
                               {
@@ -1121,11 +1128,13 @@ module.exports = {
                         "rules": [
                           {
                             "name": "everyone",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 100,
                             "type": "public"
                           },
                           {
                             "name": "all outlook",
+                            "id": "38ttpCpzrQFTMKcqFKk02m",
                             "passPercentage": 100,
                             "conditions": [
                               {
@@ -1139,6 +1148,7 @@ module.exports = {
                           },
                           {
                             "name": "all outlook and gmail",
+                            "id": "38ttpCpzrQFTMKcqFKk02n",
                             "passPercentage": 100,
                             "conditions": [
                               {
@@ -1340,6 +1350,7 @@ module.exports = {
                         "rules": [
                           {
                             "name": "everyone",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 100,
                             "conditions": [
                               {
@@ -1349,6 +1360,7 @@ module.exports = {
                           },
                           {
                             "name": "all outlook",
+                            "id": "38ttpCpzrQFTMKcqFKk02m",
                             "passPercentage": 100,
                             "conditions": [
                               {
@@ -1362,6 +1374,7 @@ module.exports = {
                           },
                           {
                             "name": "all outlook and gmail",
+                            "id": "38ttpCpzrQFTMKcqFKk02n",
                             "passPercentage": 100,
                             "conditions": [
                               {
@@ -2272,6 +2285,234 @@ module.exports = {
           "description": "Gate id to query"
         }
       ]
+    },
+    "/gates/{gate_id}/rules/{rule_id}": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "gate_id",
+          "in": "path",
+          "required": true
+        },
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "rule_id",
+          "in": "path",
+          "required": true
+        }
+      ],
+      "patch": {
+        "summary": "Update Gate Rule",
+        "tags": [
+          "Gates"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "$ref": "../models/message.json"
+                    },
+                    "data": {
+                      "$ref": "../models/gate.json"
+                    }
+                  }
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "message": "Gate updated successfully.",
+                      "data": {
+                        "id": "a_gate",
+                        "isEnabled": true,
+                        "description": "helpful summary of what this gate does",
+                        "status": "In Progress",
+                        "lastModifierName": "CONSOLE API",
+                        "lastModifierID": "1vaasdfLlkaujjajiuOSBP2",
+                        "rules": [
+                          {
+                            "name": "All Conditions",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
+                            "passPercentage": 10,
+                            "conditions": [
+                              {
+                                "type": "user_id",
+                                "targetValue": [
+                                  "35sClJFs8l0y5uRQhDwUDo"
+                                ],
+                                "operator": "any"
+                              }
+                            ],
+                            "environments": [
+                              "staging"
+                            ]
+                          }
+                        ],
+                        "tags": [
+                          "* Core"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "$ref": "../models/status.json"
+                    },
+                    "message": {
+                      "$ref": "../models/message.json"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "x-stoplight": {
+                        "id": "0awd0a8c3op74"
+                      },
+                      "items": {
+                        "$ref": "../models/error.json"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "Duplicate rule name": {
+                    "value": {
+                      "status": 400,
+                      "message": "Duplicate rule name(s) given",
+                      "errors": [
+                        {
+                          "property": "rules",
+                          "errorMessage": "Duplicate rule name(s) given"
+                        }
+                      ]
+                    }
+                  },
+                  "Duplicate rule ID": {
+                    "value": {
+                      "status": 400,
+                      "message": "Duplicate rule IDs given",
+                      "errors": [
+                        {
+                          "property": "rules",
+                          "errorMessage": "Duplicate rule IDs given"
+                        }
+                      ]
+                    }
+                  },
+                  "Nonexistent rule ID": {
+                    "value": {
+                      "status": 400,
+                      "message": "A provided rule ID does not match an existing rule ID",
+                      "errors": [
+                        {
+                          "property": "rules",
+                          "errorMessage": "A provided rule ID does not match an existing rule ID"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "patch-gates-gate_id-rules-rule_id",
+        "x-stoplight": {
+          "id": "t5iej5olk0qgp"
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "crtdj4g1d3it8"
+                    },
+                    "example": "All Conditions"
+                  },
+                  "id": {
+                    "type": "string",
+                    "x-stoplight": {
+                      "id": "ts2m44t3xbffn"
+                    },
+                    "example": "38ttpCpzrQFTMKcqFKk02l"
+                  },
+                  "passPercentage": {
+                    "type": "number",
+                    "x-stoplight": {
+                      "id": "ywuhd2cfth65a"
+                    },
+                    "minimum": 0,
+                    "maximum": 100,
+                    "example": 10
+                  },
+                  "conditions": {
+                    "x-stoplight": {
+                      "id": "cedecip4etuwv"
+                    },
+                    "type": "array",
+                    "items": {
+                      "$ref": "../models/condition.json"
+                    }
+                  },
+                  "environments": {
+                    "type": "array",
+                    "x-stoplight": {
+                      "id": "c1mifsawut2bt"
+                    },
+                    "items": {
+                      "x-stoplight": {
+                        "id": "5mo159ziiuy2m"
+                      },
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "Example 1": {
+                  "value": {
+                    "name": "All Conditions",
+                    "id": "38ttpCpzrQFTMKcqFKk02l",
+                    "passPercentage": 10,
+                    "conditions": [
+                      {
+                        "type": "user_id",
+                        "targetValue": [
+                          "35sClJFs8l0y5uRQhDwUDo"
+                        ],
+                        "operator": "any"
+                      }
+                    ],
+                    "environments": [
+                      "staging"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/docs/console-api/openapi/segments.js
+++ b/docs/console-api/openapi/segments.js
@@ -116,6 +116,7 @@ module.exports = {
                           "count": 0,
                           "rules": {
                             "name": "All Conditions",
+                            "id": "38ttpCpzrQFTMKcqFKk02l",
                             "passPercentage": 10,
                             "conditions": [
                               {


### PR DESCRIPTION
Add 'id' field to rule, both in the request body and the response body. Also added 'environments' field as well, looks like it had yet to be added to the docs.

NOTE: the current system of using 1 rule model across both requests and responses for all of gates/segments/dynamic configs is not quite right, there should be some redesign here. e.g., the 'returnValue' JSON field is a required field for gate updates/responses, although this is not true of the actual API