### PR TITLE
[docs] fix a typo in environment specific SDK keys page

### DIFF
--- a/docs/guides/using-environments.md
+++ b/docs/guides/using-environments.md
@@ -14,7 +14,7 @@ There are two main levers for setting environment-
 2. **Environment tier at SDK initialization**- used for evaluating rules   
 
 ### Environment-specific SDK Keys
-Configuring an environment-specific SDK key enables you to control which rule-sets are sent to a given SDK based on environment. For example, if an SDK it initialized with an API key set to development, it will not know about any rules that have been set for any other environment. For more information, see the [Per-Environment API keys section](#per-environment-api-keys) further down this page.
+Configuring an environment-specific SDK key enables you to control which rule-sets are sent to a given SDK based on environment. For example, if an SDK is initialized with an API key set to development, it will not know about any rules that have been set for any other environment. For more information, see the [Per-Environment API keys section](#per-environment-api-keys) further down this page.
 
 ### Environment Tier Parameter 
 It's important to note that SDK keys can correspond to multiple environments, so you need to set the environment tier on SDK initialization explicitly, even if you are using an environment-specific SDK key. You can set the environment via the `StatsigOptions` parameter.  All SDKs accept an SDK key and an (optional) `StatsigOptions` dictionary of parameters.


### PR DESCRIPTION
a minor typo "it" -> "is" 