### PR TITLE
Clarify behavior of /exposure_count Console API

### DIFF
--- a/docs/console-api/openapi/exposure-count.js
+++ b/docs/console-api/openapi/exposure-count.js
@@ -17,9 +17,9 @@ module.exports = {
     "/exposure_count": {
       "parameters": [],
       "get": {
-        "summary": "Read Exposure Count Data",
+        "summary": "Read Exposure Event Count",
         "operationId": "get-users-userId",
-        "description": "Get exposure counts for selected configs over the selected date range",
+        "description": "Get the count of exposure events recently received by Statsig.",
         "responses": {
           "200": {
             "description": "OK",


### PR DESCRIPTION
This API does not return the number of exposures on a config. 

It is actually a count of the exposure events recently received by Statsig, so if exposure events are sent to Statsig late, the output of this API will not accurately reflect the actual exposures on a config at the time of the request.