### PR TITLE
feat: add cloudflare proxy instructions

### DIFF
--- a/docs/infrastructure/custom_proxy.md
+++ b/docs/infrastructure/custom_proxy.md
@@ -3,19 +3,23 @@ title: Custom Proxy for Statsig API
 slug: /custom_proxy
 ---
 
+## Overview
+
 Instead of sending API requests directly to Statsig, you can set up your own environment that proxies requests from your custom domain name to Statsig.
 
 There are many ways to set up custom proxies. We are showing instructions for a few common service providers here.
 
-## AWS CloudFront
+## Approaches
 
-### Prerequisites
+### AWS CloudFront
+
+#### Prerequisites
 
 - Write access to your DNS settings.
 - Write access on your AWS CloudFront and Lambda console.
 - Access to a SSL certificate for your custom domain.
 
-### Setup
+#### Setup
 
 On your [AWS CloudFront console](https://console.aws.amazon.com/cloudfront/),
 
@@ -25,7 +29,7 @@ On your [AWS CloudFront console](https://console.aws.amazon.com/cloudfront/),
   - Set the Origin Domain to `api.statsig.com`.
   - Set the Protocol to `HTTPS only`.
 
-![Origin section](https://user-images.githubusercontent.com/7304774/178337858-834c6762-15b4-410d-91bb-68e04932523e.png)
+  ![Origin section](https://user-images.githubusercontent.com/7304774/178337858-834c6762-15b4-410d-91bb-68e04932523e.png)
 
 - In the Default cache behavior section,
 
@@ -33,23 +37,23 @@ On your [AWS CloudFront console](https://console.aws.amazon.com/cloudfront/),
   - Set Allowed HTTP methods to `GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE`.
   - In the Cache Key and origin requests subsection, allow all headers and parameters to be forwarded to the Origin, and allow CORS requests for the Origin.
 
-![Default cache behavior section](https://user-images.githubusercontent.com/7304774/178590547-acdedcb6-e15a-4086-a29f-0657242d9894.png)
+  ![Default cache behavior section](https://user-images.githubusercontent.com/7304774/178590547-acdedcb6-e15a-4086-a29f-0657242d9894.png)
 
 - In Function associations section,
 
   - Add a Lambda@Edge function to Origin request to rewrite the `Host` header to `api.statsig.com`. Please refer to [the AWS tutorial on creating a Lambda@Edge function](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-how-it-works-tutorial.html).
 
-![Function associations section](https://user-images.githubusercontent.com/7304774/178591897-a93a046a-c76f-4fc6-ab0c-86452de99be7.png)
-  
-  You can use the following javascript code snippet in your Lambda@Edge function:
+  ![Function associations section](https://user-images.githubusercontent.com/7304774/178591897-a93a046a-c76f-4fc6-ab0c-86452de99be7.png)
 
-  ```javascript
-  exports.handler = (event, context, callback) => {
-    const request = event.Records[0].cf.request;
-    request.headers.host[0].value = 'api.statsig.com';
-    return callback(null, request);
-  };
-  ```
+You can use the following javascript code snippet in your Lambda@Edge function:
+
+```javascript
+exports.handler = (event, context, callback) => {
+  const request = event.Records[0].cf.request;
+  request.headers.host[0].value = "api.statsig.com";
+  return callback(null, request);
+};
+```
 
 - In Settings,
 
@@ -64,11 +68,68 @@ On your [AWS CloudFront console](https://console.aws.amazon.com/cloudfront/),
 In your DNS settings (depending on your DNS provider),
 
 - Add a CNAME record in your custom DNS record:
-  
+
   - Host name: `statsig.example.com`
   - Type: `CNAME`
   - Data: `d111111abcdef8.cloudfront.net` (The Distribution domain name from AWS)
 
-### Update Statsig SDK to use your custom domain
+- Your proxy should now be setup. See [Using Your Proxy](#using-your-proxy) for instructions on how to configure your Statsig SDK.
 
-When using Statsig SDK, make sure to update the `api` parameter in the [Statsig Options](/client/jsClientSDK#statsig-options) to your custom domain with `/v1/` appended, e.g. `https://statsig.example.com/v1/`.
+### Cloudflare Worker
+
+#### Prerequisites
+
+You will need a Cloudflare account. Visit [https://www.cloudflare.com](https://www.cloudflare.com/) to set one up.
+
+#### Setup
+
+Once you are logged into Cloudflare. You can follow these steps:
+
+1.  Navigate to "Workers & Pages > Overview" in the left rail to create a new worker.
+
+    ![1-cloudflare-create](https://github.com/statsig-io/ios-sdk/assets/95646168/39bcd1ad-ddcc-4be9-9d71-905ed6a90b8b)
+
+    **Note: You may see a different experience if you already have workers on your account.**
+
+2.  Name you new worker whatever you would like and then click "Deploy".
+
+    ![2-cloudflare-deploy](https://github.com/statsig-io/ios-sdk/assets/95646168/9d728e12-675e-4648-b6ee-ce84c72b305c)
+
+3.  Once deployed, click "Edit Code".
+
+    ![3-cloudflare-edit-code](https://github.com/statsig-io/ios-sdk/assets/95646168/8c971a58-5bb7-4faa-a7ba-4574ab29f0ce)
+
+4.  Copy and paste the following snippet into the `worker.js` file, then hit "Deploy".
+
+    ```javascript
+    export default {
+      async fetch(request, _env, _ctx) {
+        const url = new URL(request.url);
+
+        const original = new Request(request);
+        original.headers.delete("cookie");
+        return fetch(
+          `https://statsigapi.net${url.pathname}${url.search}`,
+          original
+        );
+      },
+    };
+    ```
+
+    ![4-cloudflare-paste-snippet](https://github.com/statsig-io/ios-sdk/assets/95646168/558498dd-159f-409e-acef-a31e0dff86c2)
+
+5.  Your worker should now be deployed and ready to use. See [Using Your Proxy](#using-your-proxy) for instructions on how to configure your Statsig SDK.
+
+## Using Your Proxy
+
+Once you have a proxy setup, you will need to take its URL and apply it to the SDK. To do this, you can use `StatsigOptions.api`. You can visit [Statsig Options](/client/javascript-sdk#statsig-options) to read about the Javascript specific StatsigOptions, but all SDKs have the ability to override the api via `StatsigOptions.api`.
+
+The following is pseudo code of what initializing with a proxy looks like:
+
+```typescript
+Statsig.initialize(mySdkKey, myUser, { api: "https://my-statsig-proxy.com" });
+```
+
+:::note
+Depending on the SDK type, version, and proxy approach you are using, you may need to append `'/v1'` to the end of your api string. eg `"https://my-statsig-proxy.com/v1"`
+:::


### PR DESCRIPTION
Adds a step by step guide on how to setup a proxy with Cloudflare to send all Statsig SDK network requests through.