### PR TITLE
Add ActionType and ActionTypes to Audit Log GET Docs

### DIFF
--- a/docs/console-api/openapi/audit-logs/audit-log-data.json
+++ b/docs/console-api/openapi/audit-logs/audit-log-data.json
@@ -356,6 +356,21 @@
             "name": "tags",
             "description": "List of tags to filter by"
           },
+          {
+            "schema": { "type": "string", "example": "gate_create" },
+            "in": "query",
+            "name": "actionType",
+            "description": "Action type to filter by"
+          },
+          {
+            "schema": {
+              "type": "array",
+              "example": "[gate_create, gate_update]"
+            },
+            "in": "query",
+            "name": "actionTypes",
+            "description": "List of action types to filter "
+          },
           { "$ref": "#/components/parameters/pagination-limit" },
           { "$ref": "#/components/parameters/pagination-page" },
           { "$ref": "#/components/parameters/date-start-string" },


### PR DESCRIPTION
## Changes
- Add the two fields for actionType and actionTypes
- We need both due to next.js playing weird with array inputs

## Test
OpenAI View

![Docs.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/VC7JYOe9qWUkL7Zxs8Bd/cc787e54-94b0-4b48-81ee-0bb210a124bb.png)

Example works!
![Screenshot 2024-05-31 at 3.56.38 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/VC7JYOe9qWUkL7Zxs8Bd/0af878a6-d0b2-4c5c-af54-dae80b3a49cb.png)

