### PR TITLE
[docs][exp] make_decision require id instead groupId

### DIFF
--- a/docs/console-api/openapi/experiments/experiments-data.json
+++ b/docs/console-api/openapi/experiments/experiments-data.json
@@ -2662,9 +2662,7 @@
             "$ref": "#/components/responses/experiment_404.json"
           }
         },
-        "tags": [
-          "Experiments"
-        ],
+        "tags": ["Experiments"],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2678,9 +2676,9 @@
                   }
                 },
                 "properties": {
-                  "groupID": {
+                  "id": {
                     "type": "string",
-                    "description": "The groupID to be selected as the winner"
+                    "description": "The id of the group to be selected as the winner"
                   },
                   "decisionReason": {
                     "type": "string",
@@ -2695,7 +2693,7 @@
               "examples": {
                 "example-1": {
                   "value": {
-                    "groupID": "red",
+                    "id": "34RLl9bjstsTESTvBxTe4N",
                     "decisionReason": "Your reason for stopping early",
                     "removeTargeting": false
                   }


### PR DESCRIPTION
Updated experiment make_decision endpoint to require id instead of groupId


![Screenshot 2024-06-10 at 11.59.17 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7jJNDPjuGvmcRWvn25p2/5e703e72-f834-46b0-ac55-d6a1e341cdcc.png)

![Screenshot 2024-06-10 at 11.59.12 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/7jJNDPjuGvmcRWvn25p2/f013a53e-b9ad-42d5-8b61-d36e596bcda9.png)

