### PR TITLE
Update metric type when create exp

### DIFF
--- a/docs/console-api/models/experiment_metric.json
+++ b/docs/console-api/models/experiment_metric.json
@@ -10,8 +10,8 @@
     },
     "type": {
       "type": "string",
-      "description": "ID type used for this metric",
-      "example": "userID"
+      "description": "Metric type",
+      "example": "sum"
     }
   },
   "required": [


### PR DESCRIPTION
as title

example
```
{
    "name": "an_test1_experiment",
    "description": "hello",
    "secondaryMetrics": [
        {
            "name": "add_to_cart",
            "type": "event_count"
        }
    ]

}
```
