### PR TITLE
remove public install url for slack app

### DIFF
--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -10,31 +10,16 @@ The Statsig integration for Slack allows you to receive Statsig project updates 
 ![image](https://github.com/statsig-io/docs/assets/111380336/8ebaaf3e-9fb9-477c-be1d-17275690ab56)
 ![image](https://github.com/statsig-io/docs/assets/111380336/38c587d3-f723-486a-99fb-af515a2c1911)
 
-## Install
-:::info
-If you want to set up only [Project Notifications](#project-notification-settings) or [Personal Notifications](#personal-notification-settings), skip the install step and set up directly from Console.
-:::
-
-1. Click the button below to authorize the Statsig App for Slack to your workspace
-<a href="https://slack.com/oauth/v2/authorize?client_id=1857368318405.2078343039634&scope=chat:write,incoming-webhook&state=docs&user_scope="><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
-
-2. Select a channel to direct all project-level messages.
-![image](https://github.com/statsig-io/docs/assets/111380336/7fd720bd-e7eb-4201-88e7-0a480a3dd7ed)
-
-3. Select the Statsig project you want this channel to be subscribed to
-![image](https://github.com/statsig-io/docs/assets/111380336/02f7edac-9dd3-44df-9edd-41c791ef3bc2)
-
-That's it! You should be all set up.
-
 ## Project Notifications
 To configure project notifications go to [Integrations](https://console.statsig.com/integrations).<br />
+Navigate to the Slack integration and follow the instructions to install.<br />
 Once enabled, you can opt-in to optional notifications like [Health Checks](https://docs.statsig.com/statsig-warehouse-native/guides/pulse#health-checks) and Statsig system [Status Reports](https://status.statsig.com/).<br />
 You can also filter change updates by the environment affected.
 
 ![image](https://github.com/statsig-io/docs/assets/111380336/dc58c26a-226d-41cd-bdcb-9e3ac0fe47d0)
 
 ## Personal Notifications
-To configure personal notifications, go to [Account Notifications](https://console.statsig.com/1RRPcIVb55UNFzW2IHn5im/account_notifications).<br />
+To configure personal notifications, go to [Account Notifications](https://console.statsig.com/account_notifications).<br />
 Once enabled, you can select what types of notifications you receive on Slack.
 
 ![image](https://github.com/statsig-io/docs/assets/111380336/ccd12359-806f-4ab3-bb60-27afd7feccb1)


### PR DESCRIPTION
I originally added a public install URL that can be surfaced outside of Console and would set up both Project and Personal level notifications.
But to get through Slack's app review process, we'd need to uniquely identify users for oAuth https://api.slack.com/authentication/oauth-v2#exchanging. Rather than do all that, I'm just removing the public install method. Now you have to go through Console where we have the Statsig user id.

![Screenshot 2024-06-27 at 1 06 54 PM](https://github.com/statsig-io/docs/assets/111380336/5fd68d37-7c40-4410-b75a-dbf638f0fae1)
