### PR TITLE
fix: preview action

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           lfs: true
       - run: git lfs pull
-      - uses: pnpm/action-setup@v2.4.0
+      - uses: pnpm/action-setup@v2.4.1
         with:
           version: latest
           run_install: false


### PR DESCRIPTION
```
Run pnpm/action-setup@v2.4.0
Running self-installer...
   WARN  GET https://registry.npmjs.org/pnpm error (ERR_INVALID_THIS). Will retry in 10 seconds. 2 retries left.
   WARN  GET https://registry.npmjs.org/pnpm error (ERR_INVALID_THIS). Will retry in 1 minute. 1 retries left.
   ERR_PNPM_META_FETCH_FAIL  GET https://registry.npmjs.org/pnpm: Value of "this" must be of type URLSearchParams
Error: Something went wrong, self-installer exits with code 1
```

https://github.com/pnpm/action-setup/releases/tag/v2.4.1