### PR TITLE
add script tags to embed scout copilot

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -205,6 +205,26 @@ module.exports = {
                 },
               },
             ],
+            postBodyTags: [
+              {
+                tagName: 'script',
+                attributes: {
+                  type: 'text/javascript',
+                },
+                innerHTML: `
+                  document.addEventListener('DOMContentLoaded', function() {
+                    var copilot = document.createElement('co-pilot');
+                    copilot.setAttribute('copilot_id', 'your-copilot-id-here');
+                    document.body.appendChild(copilot);
+        
+                    var script = document.createElement('script');
+                    script.setAttribute('type', 'module');
+                    script.setAttribute('src', 'https://ui.scoutos.com/copilot.js');
+                    document.body.appendChild(script);
+                  });
+                `,
+              },
+            ],
           };
         },
       };


### PR DESCRIPTION
Closes #1809

# What
Add the [Scout Copilot](https://docs.scoutos.com/guide-install-the-copilot) to Statsig's Docs site

# How
Using the [Docusaurus injectHtmlTags method](https://docusaurus.io/docs/api/plugin-methods/lifecycle-apis#injectHtmlTags)

# In action
<img width="1490" alt="Screenshot 2024-07-23 at 2 01 42 PM" src="https://github.com/user-attachments/assets/a1dd78f7-d1c9-43c3-b54d-0b5a33c11dfc">