### PR TITLE
Fix siggy config command in setup instructions

### DIFF
--- a/docs/siggy/introduction.md
+++ b/docs/siggy/introduction.md
@@ -56,8 +56,8 @@ $ npx siggy --version
 2. Configure the API keys by running:
 
 ``` bash
-$ siggy -c <console-api-key>
-$ siggy -k <client-api-key>
+$ siggy config -c <console-api-key>
+$ siggy config -k <client-api-key>
 ```
 
 :::info


### PR DESCRIPTION
The documented cli commands for configuring the siggy cli tool to use the correct api keys were missing the config command.