### PR TITLE
add named argument for StatsigOptions

### DIFF
--- a/docs/server/dotnet/_initialize.mdx
+++ b/docs/server/dotnet/_initialize.mdx
@@ -6,7 +6,7 @@ await StatsigServer.Initialize(
     "server-secret-key",
     // optionally customize the SDKs configuration via StatsigOptions
     new StatsigOptions(
-        new StatsigEnvironment(EnvironmentTier.Development)
+        environment: new StatsigEnvironment(EnvironmentTier.Development)
     )
 );
 ```

--- a/docs/server/dotnet/_options.mdx
+++ b/docs/server/dotnet/_options.mdx
@@ -2,6 +2,8 @@ import { LocalModeSnippet } from "../../sdks/_LocalModeSnippet.mdx";
 
 `Initialize()` takes an optional parameter `options` in addition to `sdkKey` and `user` that you can provide to customize the Statsig client. Here are the current options and we are always adding more to the list:
 
+- **apiUrlBase**: string, default null
+  - Allows you to override the API url base path, enabling custom/internal proxy forwarding.
 - **environment**: StatsigEnvironment, default null
   - An object you can use to set environment variables that apply to all of your users in the same session and will be used for targeting purposes.
   - The most common usage is to set the environment tier (EnvironmentTier), e.g. `new StatsigEnvironment(EnvironmentTier.Staging)`, and have feature gates pass/fail for specific environments.


### PR DESCRIPTION
Could lead to confusion when the first argument is expected to be API path. Args are already optional so just providing a named arg to clarify. 