### PR TITLE
feat: autocollapse sibiling sections in sidebar

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -237,6 +237,11 @@ const config: Config = {
   themeConfig: {
     // Replace with your project's social card
     image: "img/docs_meta_q3_2023.png",
+    docs: {
+      sidebar: {
+        autoCollapseCategories: true,
+      }
+    },
     algolia: {
       // The application ID provided by Algolia
       appId: 'JOWHDNMZRN',


### PR DESCRIPTION
One of the things that makes the current sidebar unweildy is that we never collapse open sections.  This, combined with deep nesting gets out of hand really quickly.

The only setting I found related to this helps, but this only works for expanding folders on the same level.  good start