### PR TITLE
Update MigrationFromOldReact.mdx

### DIFF
--- a/docs/client/javascript-mono/MigrationFromOldJsClient.mdx
+++ b/docs/client/javascript-mono/MigrationFromOldJsClient.mdx
@@ -68,7 +68,7 @@ statsigClient.getDynamicConfig('config_name');
 
 
 ### Bootstrapping
-If you are using a server SDK to bootstrap your js/react app, you will need to make some updates to how your server SDK generates values.  One of the optimizations we made with this new js-client SDK was to remove the `sha256` library for hashing gate/experiment names.  Instead, we use a `djb2` hash.  By default, all server SDKs generate `sha256` hashes of gate/experiment names in the `getClientInitializeResponse` method.  You will need to set the hash algorithm parameter to that method call to `"djb2"` instead in order to bootstrap this new client SDK.  One of the benefits to this hashing algorithm is it will make the entire payload smaller as well, so its a net win on package size, speed, and payload size for the SDK.
+If you are using a server SDK to bootstrap your js/react app, you will need to make some updates to how your server SDK generates values.  One of the optimizations we made with this new js-client SDK was to remove the `sha256` library for hashing gate/experiment names.  Instead, we use a `djb2` hash.  By default, all server SDKs generate `sha256` hashes of gate/experiment names in the `getClientInitializeResponse` method.  You will need to set the hash algorithm parameter to that method call to `"djb2"` instead in order to bootstrap this new client SDK.  One of the benefits to this hashing algorithm is it will make the entire payload smaller as well, so its a net win on package size, speed, and payload size for the SDK.  This does not change any of the bucketing logic, only the obfuscation method used for the payload.
 
 For example, if you are bootstrapping from a nodejs app, you will need to do:
 

--- a/docs/client/javascript-mono/MigrationFromOldReact.mdx
+++ b/docs/client/javascript-mono/MigrationFromOldReact.mdx
@@ -85,7 +85,7 @@ Read the [Initialization Strategies](/client/javascript-sdk/init-strategies) gui
 ### Bootstrapping the StatsigClient
 If you are using a Statsig Server SDK to bootstrap the Statsig Client used by your React app, you may need to make some updates to how your server SDK generates values.
 One of the optimizations we made with the `@statsig/js-client` SDK was to remove the `sha256` library for hashing gate/experiment names. 
-Instead, we use a `djb2` hash. 
+Instead, we use a `djb2` hash. This does not change any of the bucketing logic, only the obfuscation method used for the payload.
 
 By default, all server SDKs generate `sha256` hashes of gate/experiment names in the `getClientInitializeResponse` method.
 You will need to set the hash algorithm parameter to that method call to `"djb2"` instead in order to bootstrap this new client SDK. 


### PR DESCRIPTION
clarify docs after this question:

Hi Statsig team, I'm currently working on [migrating](https://docs.statsig.com/client/javascript-sdk/migrating-from-statsig-react) to from statsig-react to @statsig/react-bindings, and one of the steps is to change the hashing algorithm used from (default) sha-256 to djb2. However, Statsig's [FAQ](https://docs.statsig.com/faq) notes that the hashing algorithm is used to bucket users into different experiment groups. Does that mean that this migration will cause some users to get bucketed differently and see different treatments? If so, would it make sense to try to wrap up all currently running experiments before shipping the migration? Thanks!