### PR TITLE
bump http-proxy-middleware version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9222,9 +9222,10 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "overrides": {
     "path-to-regexp@0": "0.1.10",
     "path-to-regexp@1": "1.9.0",
-    "body-parser": "1.20.3"
+    "body-parser": "1.20.3",
+    "http-proxy-middleware": "2.0.7"
   },
   "packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e"
 }


### PR DESCRIPTION
per title
fix https://github.com/statsig-io/docs/security/dependabot/88 

# test
`npm install` 
then 
`pnpm dev` 
open `localhost:3000` and click through a few pages