### PR TITLE
Update GitHubEmbed.js

### DIFF
--- a/src/components/GitHubEmbed.js
+++ b/src/components/GitHubEmbed.js
@@ -114,8 +114,6 @@ export default function GitHubEmbed({ url, language }) {
   return (
     <div
       style={{
-        maxHeight: content ? "1000px" : "200px",
-        transition: "max-height 1s ease-out",
         overflow: "hidden",
       }}
     >


### PR DESCRIPTION
Some code blocks are going over the 1000px limit, and the animation is causing jumpiness when you're navigating to a #name. 