### PR TITLE
remove react-native from react-native-expo-bindings

### DIFF
--- a/docs/client/concepts/parameter-stores.mdx
+++ b/docs/client/concepts/parameter-stores.mdx
@@ -59,7 +59,7 @@ Parameter Stores are available in the following SDKs:
 
 - **Android SDK** v4.33.0+
 - **iOS SDK** v1.45.0+
-- **@statsig/js-client**, **@statsig/react-bindings**, **@statsig/react-native-bindings**, **@statsig/react-native-expo-bindings** v1.4.0+
+- **@statsig/js-client**, **@statsig/react-bindings**, **@statsig/react-native-bindings**, **@statsig/expo-bindings** v1.4.0+
 - **Dart SDK** v1.2.1+
 
 ---

--- a/docs/client/javascript-mono/react/_reactGatesAndConfigs.mdx
+++ b/docs/client/javascript-mono/react/_reactGatesAndConfigs.mdx
@@ -17,7 +17,7 @@ const { client } = useStatsigClient();`}
     case 'react-native-expo':
       return (
         <pre><code className="language-jsx">
-        {`import { useStatsigClient } from "@statsig/react-native-expo-bindings";
+        {`import { useStatsigClient } from "@statsig/expo-bindings";
 
 const { client } = useStatsigClient();`}
         </code></pre>


### PR DESCRIPTION
[the npm package is called `@statsig/expo-bindings`, not `@statsig/react-native-expo-bindings`](https://www.npmjs.com/package/@statsig/expo-bindings)