### PR TITLE
chore: add snippet for go gcir

### DIFF
--- a/docs/server/Templates/_ClientInitResponse.mdx
+++ b/docs/server/Templates/_ClientInitResponse.mdx
@@ -40,3 +40,14 @@ Alternatively, if you wish to use the `stableID` field rather than a custom ID, 
 - Override the `stableID` in the client SDK by getting the value from the cookie and setting the `overrideStableID`
   parameter in `StatsigOptions`
 - Set the `stableID` field on the `StatsigUser` object in the `customIDs` map when generating the initialize response from the SDK
+
+
+### getClientInitializeResponse and the legacy JS SDK
+
+If you are migrating from the legacy JS Client, you will need to make some updates to 
+how your server SDK generates values. 
+The default hashing algorithm was changed from `sha256` to `djb2` for performance and size reasons. 
+
+See the [Bootstrapping Migration Docs](https://docs.statsig.com/client/javascript-sdk/migrating-from-statsig-js/#bootstrapping) for more.
+
+

--- a/docs/server/go/_clientInitResponse.mdx
+++ b/docs/server/go/_clientInitResponse.mdx
@@ -1,0 +1,9 @@
+```swift
+user := statsig.User{UserID: "some_user_id"}
+options := statsig.GCIROptions{}
+options.ClientKey = "client-YOUR_CLIENT_KEY"
+
+result := statsig.GetClientInitializeResponseWithOptions(user, &options)
+
+// You can then pass 'result' into a Statsig Client SDK
+```

--- a/docs/server/golangSDK.mdx
+++ b/docs/server/golangSDK.mdx
@@ -42,6 +42,7 @@ import PersistentStorageInterface from "./go/_persistentStorageInterface.mdx";
 import PersistentStorageExample from "./go/_persistentStorageExample.mdx";
 import * as ReferenceSnippets from "./go/_reference.mdx";
 import MultiInstanceExample from "./go/_multiInstanceExample.mdx";
+import ClientInitResponseSnippet from "./go/_clientInitResponse.mdx";
 
 export const Builder = SDKDocsBuilder({
   sections: [
@@ -82,6 +83,15 @@ export const Builder = SDKDocsBuilder({
     [
       DataStore,
       { interface: <DataStoreInterface />, example: <DataStoreExample /> },
+    ],
+    [
+      ClientInitResponse,
+      {
+        sdkName: "GO",
+        addedInVersion: "1.12.0",
+        snippet: <ClientInitResponseSnippet />,
+        signature: () => <code>getClientInitializeResponse</code>,
+      },
     ],
     [
       UserPersistentStorage,


### PR DESCRIPTION
Someone was confused as to why their bootstrapping suddenly stopped working when they migrated from statsig-js to @statsig/js-client. Add more docs around the GO gcir function with links to the migration docs 