### PR TITLE
bump path-to-regexp version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7771,9 +7771,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/express/node_modules/range-parser": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "node": ">=18.0"
   },
   "overrides": {
-    "path-to-regexp@0": "0.1.10",
+    "path-to-regexp@0": "0.1.12",
     "path-to-regexp@1": "1.9.0",
     "body-parser": "1.20.3",
     "http-proxy-middleware": "2.0.7"


### PR DESCRIPTION
per title, fix https://github.com/statsig-io/docs/security/dependabot/90 

after update `package.json`, 
run `npm install` 