### PR TITLE
Move SCIM docs around to be less confusing

### DIFF
--- a/docs/access-management/scim/concepts.mdx
+++ b/docs/access-management/scim/concepts.mdx
@@ -26,8 +26,6 @@ Each user has the following attributes:
 
 ## Groups
 
-![img](/img/okta_scim_steps/okta-statsig-group.png)
-
 Groups in SCIM represent Statsig Projects with specific roles.
 For example, a Project named "Project A" with a role of "Admin" would be represented as a group in SCIM.
 The group name for this example project would be `Statsig-ProjectA-Admin`.
@@ -36,3 +34,9 @@ Important notes about groups:
 
 - We do not allow group deletion via SCIM
 - Group names cannot be updated through SCIM
+
+### General Mapping Between SCIM and Statsig
+
+![img](/img/okta_scim_steps/okta-statsig-group.png)
+
+


### PR DESCRIPTION
The ordering of this page pushed the important section below the large confusing chart, move it around to make it less confusing