### PR TITLE
SCIM - Split off docs and make Troubleshooting page

### DIFF
--- a/docs/access-management/scim/okta_scim_org_roles.mdx
+++ b/docs/access-management/scim/okta_scim_org_roles.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_label: Okta SCIM Org Roles
+title: Okta SCIM Org Roles
+---
+
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
+
+## Update Okta User Org Role
+
+For every user, Statsig surfaces a SCIM field named `statsigOrgRole`. Through this field, you can manage organization user roles.
+Currently, Okta can only push role updates to Statsig.
+
+### Step 1. Create the Custom Attribute in Okta
+
+Navigate to `Directory > Profile Editor` and select the User (default) Okta profile. This represents all of the Okta users' attributes.
+Scroll down and press `Add Attribute` and fill out the new attribute to have the variable name `statsigOrgRole`.
+
+![img](/img/okta_scim_steps/org_steps/step1.png)
+
+### Step 2. Create the Custom Attribute in the Statsig SCIM Integration
+
+Now Navigate to the `Statsig SCIM Integration's User Profile` in the `Profile Editor`.
+Add an new attribute that matches the following format:
+
+- Variable name: `statsigOrgRole`
+- External namespace: `urn:ietf:params:scim:schemas:core:2.0:User`
+
+![img](/img/okta_scim_steps/org_steps/step2.png)
+
+### Step 3. Create a Mapping from Statsig to Okta for the Custom Attribute
+
+On the same Statsig SCIM profile editor, navigate to the `Mappings` button.
+Scroll down to the new attribute `statsigOrgRole` and map `user.statsigOrgRole` to the Okta attribute `statsigOrgRole`.
+
+![img](/img/okta_scim_steps/org_steps/step3.png)
+
+### Step 4. Create a mapping from Okta to Statsig for the Custom Attribute
+
+Now navigate to the Okta User to Statsig SCIM user mapping.
+![img](/img/okta_scim_steps/org_steps/step4_1.png)
+
+Scroll down to the `statsigOrgRole` attribute and map `user.statsigOrgRole` to the Okta attribute `statsigOrgRole`.
+
+![img](/img/okta_scim_steps/org_steps/step4_2.png)
+
+Now all users will be synced with their organization role. On the Statsig SCIM integration you can modify a user's role directly as well.
+
+### Step 5. Modify Integration Mappings
+
+Navigate to the Statsig SCIM integration provisioning section.
+Under the "To App" tab, scroll down to the `statsigOrgRole` attribute.
+
+![img](/img/okta_scim_steps/org_steps/step5_1.png)
+Set the attribute value to `Map from Okta Profile` and `statsigOrgRole`.
+Set apply on `Create and update`.
+
+![img](/img/okta_scim_steps/org_steps/step5_2.png)
+
+Navigate to the "To Okta" tab and scroll down to the `statsigOrgRole` attribute.
+![img](/img/okta_scim_steps/org_steps/step5_3.png)
+
+Set the attribute value to `Map from Statsig Profile` and `statsigOrgRole`.
+Set apply on `Create`.
+
+![img](/img/okta_scim_steps/org_steps/step5_4.png)

--- a/docs/access-management/scim/okta_scim_setup.mdx
+++ b/docs/access-management/scim/okta_scim_setup.mdx
@@ -1,0 +1,89 @@
+---
+sidebar_label: Okta SCIM Setup
+title: Okta SCIM Setup
+---
+
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
+
+# Okta SCIM Provisioning
+
+<br />
+This guide outlines the process for setting up SCIM (System for Cross-domain Identity
+Management) integration between Statsig and Okta. This integration allows for automated
+user provisioning and management.
+
+## Prerequisites
+
+- An Okta account with admin access
+- A SCIM Key from the [Statsig Console](/access-management/scim/overview#how-to-obtain-scim-auth-key) (requires Statsig Org Admin rights)
+
+:::note
+
+### Integration Notes
+
+- User email management is not enabled on SCIM yet.
+- When a user is removed from Statsig, they will be automatically unassigned in Okta. Conversely, if a user is unassigned or deactivated in Okta, they will be removed from the Statsig Organization.
+- Creation of Statsig Projects and Roles is not supported via SCIM.
+  :::
+
+## Step 1: Create a New App Integration in Okta
+
+- Log in to your Okta admin console
+- Navigate to Applications > Applications > Create App Integration
+- Select "SWA - Secure Web Authentication"
+
+![img](/img/okta_scim_steps/step1-create-new-custom-integration.png)
+
+## Step 2: Configure App Settings
+
+- Set the App name to "Statsig SCIM"
+- Enter a placeholder URL for the App Login Page (this is a required field but not used for SCIM). Ex: `https://console.statsig.com/`
+
+![img](/img/okta_scim_steps/step2-configure-app-settings.png)
+
+## Step 3: Enable SCIM Provisioning
+
+- After creating the integration, go to the "General" tab
+- Click on "Edit" in the "Provisioning" section
+- Enable "SCIM Provisioning"
+
+![img](/img/okta_scim_steps/step3-enable-scim.png)
+
+## Step 4: Configure SCIM Settings
+
+:::info
+
+`Import Groups` requires an Okta flag `SELECTIVE_APP_IMPORT_PLATFORM`. If this flag is enabled for your organization, please select this option. If it is not, leave it unchecked.
+
+:::
+
+- Navigate to the `Provisioning` tab
+- Set the SCIM connector base URL to: [https://statsigapi.net/scim](https://statsigapi.net/scim)
+- Set "Unique identifier field for users" to `userName`
+- Enable
+  - `Import New Users and Profile Update`
+  - `Push New Users`
+  - `Push Profile Updates`
+  - `Push Groups`
+  - `Import Groups` (Only if your organization has the `SELECTIVE_APP_IMPORT_PLATFORM` flag enabled, see note above)
+- Set the authentication mode to "HTTP Header"
+- For the authorization header, use the SCIM Bearer token generated in Statsig by your Org Admin. See [How to Obtain SCIM Auth Key](/access-management/scim/overview#how-to-obtain-scim-auth-key) for more details.
+
+![img](/img/okta_scim_steps/step4.png)
+
+## Step 5: Configure Okta to Statsig Settings
+
+- Enable "Create Users"
+- Enable "Update User Attributes"
+- Enable "Deactivate Users"
+
+![img](/img/okta_scim_steps/step5-configure-okta-to-statsig-settings.png)
+
+## Step 6: Import Existing Statsig Users and Groups
+
+- In Okta, go to the Statsig app's "Import" tab
+- Click "Import Now" to fetch existing Statsig users and groups
+- Process the imported users as needed
+
+![img](/img/okta_scim_steps/step6-import-existing-users.png)

--- a/docs/access-management/scim/okta_scim_troubleshooting.mdx
+++ b/docs/access-management/scim/okta_scim_troubleshooting.mdx
@@ -1,0 +1,33 @@
+---
+sidebar_label: Troubleshooting
+title: Okta SCIM Troubleshooting
+---
+
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
+
+
+# Okta SCIM Troubleshooting
+
+## Common SCIM Errors
+
+| Error | Solution |
+|-------|----------|
+| User userID is not allowed to be created in this organization | Ensure that the users you are assigning to Statsig have the correct email domain. We require users to have the org's email domain. |
+| Owner cannot be modified | The owner of the organization can only be replaced by another user. |
+| Cannot set multiple owners | We do not allow multiple owners for an organization. Ensure that you are not trying to set multiple owners for the organization. |
+| Project creation is not supported via SCIM | Project creation is not supported via SCIM. Please create projects in the Statsig Console. |
+| Project deletion is not supported via SCIM | Project deletion is not supported via SCIM. Please delete projects in the Statsig Console. |
+
+
+## Common Issues
+
+- I'm not seeing any Statsig groups in Okta
+  - Your organization may have the Okta flag `SELECTIVE_APP_IMPORT_PLATFORM` enabled. If this is the case, you will need to select `Import Groups` in the SCIM integration settings. See the [setup page](/access-management/scim/okta_scim_setup) for more info.
+- I can't select `Import Groups` in the SCIM integration settings
+  - Your organization may have the Okta flag `SELECTIVE_APP_IMPORT_PLATFORM` disabled. If this is the case, you cannot select `Import Groups` in the SCIM integration settings. However, when importing you will see the groups in the Okta SCIM integration.
+- I'm trying to push groups but not seeing users populate those groups
+  - Ensure that the users you are pushing to Statsig are assigned to the integration.
+  - If the users are assigned, verify that the groups you are pushing to Statsig are the Statsig Groups generated on import.
+- I don't want to use Statsig generated groups, can I use my own?
+  - You can use your own groups in the push groups section. However, you will need to push these groups to a specific Statsig Project x Role Group. There is no way to push your own groups without pushing to a Statsig Project x Role Group.

--- a/docs/access-management/scim/okta_scim_user_management.mdx
+++ b/docs/access-management/scim/okta_scim_user_management.mdx
@@ -1,0 +1,57 @@
+---
+sidebar_label: Okta SCIM User Management
+title: Okta SCIM User Management
+---
+
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
+
+## Import Existing Statsig Users and Groups
+
+:::note
+Users not assigned to the integration cannot be pushed into groups.
+:::
+
+- In Okta, go to the Statsig app's "Import" tab
+- Click "Import Now" to fetch existing Statsig users and groups
+- Process the imported users as needed
+
+![img](/img/okta_scim_steps/step6-import-existing-users.png)
+
+## Manage User Assignments
+
+- Use the "Assignments" tab in Okta to add or remove users from Statsig
+- Adding a user assignment in Okta will create the user in Statsig, while removing the assignment will deactivate the user's Statsig account
+
+![img](/img/okta_scim_steps/step7-manage-user-assignments.png)
+
+## Push Groups to Statsig
+
+1. In Okta, go to the Statsig Integration's "Push Groups" tab
+   ![img](/img/okta_scim_steps/step8-push-groups-1.png)
+
+2. Click the settings button and disable "Rename Groups"
+   ![img](/img/okta_scim_steps/step8-push-groups-2.png)
+
+3. Click "Push Groups" and select the method for finding groups in Okta.
+   ![img](/img/okta_scim_steps/step8-push-groups-3.png)
+
+4. Type in and select the Okta group that will push to a Statsig Project x Role Group.
+
+- You can find Groups in left nav of Okta: `Directory > Groups`. In there, you will see the groups created from Okta and groups created by Statsig.
+- The required groups are groups you created from Okta. You can filter by choosing `Group source type` and set to `Okta groups`. If you don't have any, go ahead and create it with members as well.
+  ![img](/img/okta_scim_steps/step8-push-groups-4.png)
+
+5. Now let's link/assign Okta group you created from Okta to the Statsig groups with role you want.
+
+- Change `Match Result & Push Action` to `Link Group`
+  ![img](/img/okta_scim_steps/step8-push-groups-5.png)
+
+6. Select the Statsig Project x Role Group that the Okta group will push to.
+
+- We display the Statsig Project x Role Group with the format `Statsig-<Project Name>-<Role Name>` on Okta.
+- By default Okta only allows you to map 1 Okta Group to 1 Statsig Group.
+  ![img](/img/okta_scim_steps/step8-push-groups-6.png)
+
+7. Then link the Okta group to a Statsig Project x Role Group. On save the group should push to Statsig. All future group changes on Okta will be pushed to Statsig.
+   ![img](/img/okta_scim_steps/step8-push-groups-7.png)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -974,7 +974,18 @@ const sidebars: SidebarsConfig = {
                   items: [
                     "access-management/scim/overview",
                     "access-management/scim/concepts",
-                    "access-management/scim/okta_scim",
+                    
+                    {
+                      type: "category",
+                      label: "Okta Guide",
+                      items: [
+                        "access-management/scim/okta_scim_setup",
+                        "access-management/scim/okta_scim_user_management",
+                        "access-management/scim/okta_scim_org_roles",
+                        "access-management/scim/okta_scim_troubleshooting",
+                      
+                      ],
+                    },
                     "access-management/scim/scim-endpoints",
                   ],
                 },


### PR DESCRIPTION
The setup page has too much going on, splitting it off into multiple pages and adding a troubleshooting page
