### PR TITLE
Remove hover highlight from sidebar section titles

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -269,6 +269,11 @@ span.math.math-inline {
   margin-left: 8px;
 }
 
+.theme-doc-sidebar-item-category-level-1
+  > .menu__list-item-collapsible {
+  background: none;
+}
+
 .menu__list > .menu__list-item:first-child .menu__list-item-collapsible {
   border-top: none; /* Remove border-top for the first element */
   padding-top: 0; /* Adjust padding if necessary */


### PR DESCRIPTION
Before:

![Screenshot 2025-03-11 at 10 58 42 AM](https://github.com/user-attachments/assets/c413f0fb-969f-49c9-84d1-02cac2834890)

After:

![Screenshot 2025-03-11 at 2 27 48 PM](https://github.com/user-attachments/assets/aab98377-067b-438e-8a57-89ed75e88168)
