### PR TITLE
Only Okta Scim

### DIFF
--- a/docs/access-management/scim/okta_scim_org_roles.mdx
+++ b/docs/access-management/scim/okta_scim_org_roles.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Okta SCIM Org Roles
+sidebar_label: Org Roles
 title: Okta SCIM Org Roles
 ---
 

--- a/docs/access-management/scim/okta_scim_setup.mdx
+++ b/docs/access-management/scim/okta_scim_setup.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Okta SCIM Setup
+sidebar_label: Setup
 title: Okta SCIM Setup
 ---
 

--- a/docs/access-management/scim/okta_scim_team_management.mdx
+++ b/docs/access-management/scim/okta_scim_team_management.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Okta SCIM Team Management
+sidebar_label: Statsig Team Management
 title: Okta SCIM Team Management
 ---
 

--- a/docs/access-management/scim/okta_scim_user_management.mdx
+++ b/docs/access-management/scim/okta_scim_user_management.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_label: Okta SCIM User Management
-title: Okta SCIM User Management
+sidebar_label: User and Project/Role Management
+title: Okta SCIM User and Project/Role Management
 ---
 
 import Alert from "@mui/material/Alert";


### PR DESCRIPTION
TSIA
No need to prefix everything with Okta SCIM on the side, its already a given due to the hierarchy