### PR TITLE
Update statsig.logEvent to only use string metadata values

### DIFF
--- a/docs/guides/logging-events.mdx
+++ b/docs/guides/logging-events.mdx
@@ -124,7 +124,7 @@ statsig.logEvent(
   19.99, // Price
   { 
     item_id: 'BC22010', 
-    cart_size: 2,
+    cart_size: '2',
     user_segment: 'first_time_purchaser',
   }
 );


### PR DESCRIPTION
## Description

Server core only accepts string metadata values. This PR updates one of the examples to match that.