### PR TITLE
Fix node-core statsig.logEvent snippet

### DIFF
--- a/docs/server-core/node/_logEvent.mdx
+++ b/docs/server-core/node/_logEvent.mdx
@@ -2,6 +2,7 @@
 statsig.logEvent(
   user,
   "add_to_cart",
+  null,
   {
     price: "9.99",
     item_name: "diet_coke_48_pack"


### PR DESCRIPTION
## Description

For node core, the third parameter is always the value. If we want to pass metadata, it needs to be the fourth parameter.

![image](https://github.com/user-attachments/assets/23219926-b8f8-47f8-9e97-d42376bd774c)

