### PR TITLE
[docs] assignment sources are located in the data tab

### DIFF
--- a/docs/statsig-warehouse-native/configuration/assignment-sources.md
+++ b/docs/statsig-warehouse-native/configuration/assignment-sources.md
@@ -12,7 +12,7 @@ Assignment Sources are how you schematize your assignment data for Statsig, and 
 
 ## Creating an Assignment Source
 
-To create an assignment source, go to the experiments tab in Statsig and go to the Assignment Sources pane.
+To create an assignment source, go to the data tab in Statsig and go to the Assignment Sources pane.
 
 An Assignment Source is defined as a SQL query and a mapping of the output columns to specific fields
 Statsig requires (user identifiers, a `timestamp`, an experiment identifier, and a group identifier).


### PR DESCRIPTION
## Description

Was trying to find assignment sources and realized docs were directing me to the wrong place. Updated the instructions for creating an Assignment Source to direct users to the "data" tab instead of the "experiments" tab in Statsig.

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!