### PR TITLE
cleanup: server core installation and client statsig user reference

### DIFF
--- a/docs/client/javascript-mono/_GettingStartedFastImpl.mdx
+++ b/docs/client/javascript-mono/_GettingStartedFastImpl.mdx
@@ -88,3 +88,5 @@ Optional features:
 After installing the SDK, you can initialize it using the following code:
 
 <JSSnippets sessionReplayToggle={window.jsMonoOptDeps.sessionReplayToggle} autoCaptureToggle={window.jsMonoOptDeps.autoCaptureToggle} />
+
+See the [User (StatsigUser)](/concepts/user) doc for more information on the "user" parameter.

--- a/docs/client/javascript-mono/nextjs/_nextJSPageVsAppRouter.mdx
+++ b/docs/client/javascript-mono/nextjs/_nextJSPageVsAppRouter.mdx
@@ -126,6 +126,7 @@ export default function App({ Component, pageProps }: AppProps) {
 
 {/* Rest */}
 
+See the [User (StatsigUser)](/concepts/user) doc for more info on the user property.
 
 Now if you load your app, you should see events being sent to Statsig and if you have LogLevel set to Debug, you should see debug logs in the browsers console.
 

--- a/docs/client/javascript-mono/react/_reactSetup.mdx
+++ b/docs/client/javascript-mono/react/_reactSetup.mdx
@@ -21,7 +21,7 @@ export default App;
 
 ### Adding a user object
 
-At this point, if you run your app, you will get a type error related to the `user` prop. To fix this, you can add the user object that sets user properties like so:
+At this point, if you run your app, you will get a type error related to the `user` prop. The `user` prop is a collection of properties that you want to target in for feature gates and experiments, or metadata to slice your experiment results and event logging.  See the [User (StatsigUser)](/concepts/user) doc for more information. To fix this, you can add the user object that sets user properties like so:
 
 ```tsx
 import { StatsigProvider } from "@statsig/react-bindings";

--- a/docs/server-core/elixir/_initialize.mdx
+++ b/docs/server-core/elixir/_initialize.mdx
@@ -16,6 +16,4 @@ res = Supervisor.start_link(children, opts)
 {:ok,_} = Statsig.start_link(sdk_key, statsig_options)
 Statsig.initialize()
 
-# Don't forget to shutdown when done
-Statsig.shutdown()
 ```

--- a/docs/server-core/node/_install.mdx
+++ b/docs/server-core/node/_install.mdx
@@ -1,10 +1,12 @@
-To use the Statsig Server Core SDK, install the `@statsig/statsig-node-core` package.
-
 ```shell
 npm i @statsig/statsig-node-core
 ```
 
-SDKs are pre-built and compiled for different OSs & CPU architectures. Package managers will resolve the correct version, but if your service has locked dependencies with package-lock.json or pnpm-lock.yml, you'll need to include all versions you need. For example, if you develop locally on macOS, and deploy to linux, then you should include:
+The node SDK is pre-built and compiled for different OSs & CPU architectures. Package managers will resolve the correct version automatically.
+
+#### Frozen lockfile/locked dependencies
+If your service has locked dependencies with package-lock.json or pnpm-lock.yml, you'll need to include all versions you need. For example, if you develop locally on macOS, and deploy to linux, then you have to include:
+
 ```
 dependencies {
     "statsig/statsig-node-core-darwin-arm64": "0.1.0" // for macOS
@@ -14,7 +16,7 @@ dependencies {
 
 #### Using statsig-node-core with Next.js
 
-Node-core works well with Next, but can't be packaged with webpack. To prevent errors, designate @statsig/statsig-node-core as a serverExternalPackage in your next.config.js file:
+statsig-node-core works well with Next, but can't be packaged with webpack. To prevent errors, designate @statsig/statsig-node-core as a serverExternalPackage in your next.config.js file:
 ```jsx
 const nextConfig = {
   serverExternalPackages: ['@statsig/statsig-node-core'],

--- a/docs/server-core/python/_initialize.mdx
+++ b/docs/server-core/python/_initialize.mdx
@@ -1,18 +1,12 @@
 ```python
-from statsig_python_core import Statsig, StatsigOptions #note, import statement has underscores while install has dashes
+from statsig_python_core import Statsig, StatsigOptions # note, import statement has underscores while install has dashes
 
-
-# Simple initialization
-statsig = Statsig("secret-key")
-statsig.initialize().wait()
-
-# Or with StatsigOptions
 options = StatsigOptions()
 options.environment = "development"
 
 statsig = Statsig("secret-key", options)
 statsig.initialize().wait()
 
-# Don't forget to shutdown when done
+# If you're running this in a script, be sure to wait for shutdown at the end to flush event logs to statsig
 statsig.shutdown().wait()
 ```

--- a/docs/server-core/python/_install.mdx
+++ b/docs/server-core/python/_install.mdx
@@ -1,5 +1,3 @@
-To use the SDK, use Pip to add the Statsig Server Core package. 
-
 ```shell
 pip install statsig-python-core
 ```


### PR DESCRIPTION
## Description

Fixing docs feedback on js client/react

New Feedback Received:
URL: https://docs.statsig.com/client/javascript-sdk/react/
Feedback: Please explain whether the user object refers to the end user or the developer using statsig. This object is not explained

And cleaning up some of the server core getting started (python and node)
