### PR TITLE
[EZ] Remove line: Session replays are only recorded and stored if the environment is production

### DIFF
--- a/docs/session-replay/install.mdx
+++ b/docs/session-replay/install.mdx
@@ -93,7 +93,7 @@ import { runStatsigAutoCapture } from '@statsig/web-analytics';
 
 const client = new StatsigClient(sdkKey,
 	{ userID: "some_user_id" },
-  { environment: { tier: "production" } } // optional, pass options here if needed. Session replays are only recorded and stored if the environment is production.
+  { environment: { tier: "production" } } // optional, pass options here if needed
 );
 runStatsigSessionReplay(client);
 runStatsigAutoCapture(client);


### PR DESCRIPTION
## Description
Statement is no longer accurate
Will land this after https://app.graphite.dev/github/pr/statsig-io/statsig/59114/Allow-session-recording-on-all-tiers lands

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!