### PR TITLE
adding id type to reference section

### DIFF
--- a/docs/server/go/_reference.mdx
+++ b/docs/server/go/_reference.mdx
@@ -121,6 +121,7 @@ type FeatureGate struct {
 	Name              string             `json:"name"`
 	Value             bool               `json:"value"`
 	RuleID            string             `json:"rule_id"`
+	IDType            string             `json:"id_type"`
 	GroupName         string             `json:"group_name"`
 	EvaluationDetails *EvaluationDetails `json:"evaluation_details"`
 }
@@ -133,6 +134,7 @@ type DynamicConfig struct {
 	Name              string                 `json:"name"`
 	Value             map[string]interface{} `json:"value"`
 	RuleID            string                 `json:"rule_id"`
+	IDType            string             	 `json:"id_type"`
 	GroupName         string                 `json:"group_name"`
 	EvaluationDetails *EvaluationDetails     `json:"evaluation_details"`
   AllocatedExperimentName string           `json:"allocated_experiment_name"`
@@ -151,6 +153,7 @@ type Layer struct {
 	Name              string                 `json:"name"`
 	Value             map[string]interface{} `json:"value"`
 	RuleID            string                 `json:"rule_id"`
+	IDType            string		 `json:"id_type"`
 	GroupName         string                 `json:"group_name"`
 	EvaluationDetails *EvaluationDetails     `json:"evaluation_details"`
   AllocatedExperimentName string           `json:"allocated_experiment_name"`


### PR DESCRIPTION
documentation for exposing id type on configbase class https://linear.app/statsig/issue/SDK-1420/expose-id-type-on-layer

<img width="752" alt="image" src="https://github.com/user-attachments/assets/99c58e9c-99c3-4e36-b82b-1c6fbeb7db3b" />

## Description

Brief summary or screenshot of your changes

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!