### PR TITLE
Update _initialize.mdx

### DIFF
--- a/docs/server-core/java/_initialize.mdx
+++ b/docs/server-core/java/_initialize.mdx
@@ -14,7 +14,7 @@ StatsigOptions options = new StatsigOptions.Builder()
                     .build();
 
 Statsig myStasigServer = new Statsig(SECRET_KEY, options);
-statsig.initialize().get();
+myStasigServer.initialize().get();
 ```
 
 You can also initialize the Statsig client using the method <code>initialize_with_details</code>. This method initializes the client and returns a <code>StatsigInitializeDetails</code> struct, which includes metadata such as the success status, initialization source, and any failure details. The key difference between <code>initialize_with_details</code> and <code>initialize</code> is that this method provides additional debugging information. If initialization fails, the <code>init_success</code> field will be <code>false</code> and the <code>failure_details</code> field may be populated.


### PR DESCRIPTION
Feedback: Docs to initialize the statsig SDK appear to be incorrect: Statsig myStasigServer = new Statsig(SECRET_KEY, options);
statsig.initialize().get(); second line should be myStatsigServer.initialize().get(); I think?