### PR TITLE
chore: bump http-proxy-middleware version to 2.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9176,9 +9176,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "path-to-regexp@0": "0.1.12",
     "path-to-regexp@1": "1.9.0",
     "body-parser": "1.20.3",
-    "http-proxy-middleware": "2.0.7",
+    "http-proxy-middleware": "2.0.9",
     "image-size": "1.2.1",
     "react-router@7": "7.5.2"
   },


### PR DESCRIPTION
## Description
to fix https://github.com/statsig-io/docs/security/dependabot/106 and https://github.com/statsig-io/docs/security/dependabot/107

testing on https://682f98e642538d73f2ee51d8--cozy-fox-0defec.netlify.app
clicked through pages

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!