### PR TITLE
Fix Supported OS and Arch combinations table formatting

### DIFF
--- a/docs/server-core/java/_supported_combinations.mdx
+++ b/docs/server-core/java/_supported_combinations.mdx
@@ -4,9 +4,8 @@
 | `uber` | Self-contained JAR with both core library and native libraries for Linux (x86_64, arm64), macOS (x86_64, arm64), and Windows (x86_64) (available since version 0.4.0, if used, no other dependencies needed) | `implementation 'com.statsig:javacore:X.X.X:uber'` |
 | `macos-arm64` | macOS (Apple Silicon/ARM64) | `implementation 'com.statsig:javacore:X.X.X:macos-arm64'` |
 | `macos-x86_64` | macOS (Intel/x86_64 or AMD64) | `implementation 'com.statsig:javacore:X.X.X:macos-x86_64'` |
-
 | `windows-x86_64` | Windows (Intel/AMD 64-bit architecture, x86_64) | `implementation 'com.statsig:javacore:X.X.X:windows-x86_64'` |
 | `amazonlinux2-arm64` | Amazon Linux 2 (ARM64) | `implementation 'com.statsig:javacore:X.X.X:amazonlinux2-arm64'` |
-| `amazonlinux2-x86_64`  | Amazon Linux 2 (Intel/AMD 64-bit, x86_64) | `implementation 'com.statsig:javacore:X.X.X:amazonlinux2-x86_64'` |
+| `amazonlinux2-x86_64` | Amazon Linux 2 (Intel/AMD 64-bit, x86_64) | `implementation 'com.statsig:javacore:X.X.X:amazonlinux2-x86_64'` |
 | `amazonlinux2023-arm64` | Amazon Linux 2023 (ARM64) | `implementation 'com.statsig:javacore:X.X.X:amazonlinux2023-arm64'` |
-| `amazonlinux2023-x86_64`  | Amazon Linux 2023 (Intel/AMD 64-bit, x86_64) | `implementation 'com.statsig:javacore:X.X.X:amazonlinux2023-x86_64'` |
+| `amazonlinux2023-x86_64` | Amazon Linux 2023 (Intel/AMD 64-bit, x86_64) | `implementation 'com.statsig:javacore:X.X.X:amazonlinux2023-x86_64'` |


### PR DESCRIPTION
# PR Description

This PR fixes the "Supported OS and Arch combinations" table formatting in the Java core documentation. The table is now correctly formatted and displays properly on the local development server.

![Localhost Screenshot](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org_NcsKoZ6bXUL52UGA/d9e9c340-36e0-4d58-ae12-c151f34da848/localhost_3000_194303.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT7RFVAS7YO%2F20250612%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250612T203727Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEB0aCXVzLWVhc3QtMSJIMEYCIQDonvQEEUbpQy6w1RyExWpXVuAIWTvmj9%2FgzdOGOXX0ogIhAMtDKosfYbjL5WOWnlldNgA49HW2qrRv8B0Z09Kw4sKrKsAFCPX%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQARoMMjcyNTA2NDk4MzAzIgw4JlwTVMWFhPduw7IqlAXSDp5KdgaCv4gUFUoP6BER87Ruy5qx7vm9NCcLWeX%2BxY%2FCELAItOC64WIjBoJwwySHbjZQlHv7%2FjQvnC0NeGuDHyCJu%2FjzYDRw4ABurjZtHz5uzRgeDQmk7TLDafEtciNQLrNCQVAjcnglRT7YLbneV3KVIt4VYxocapbAqyeQH13O5Ervxtw7oGGksiT47HEI8UG5MdP5jILyy1v92OSvlMVxVsd7rZHzjkxNuSK%2FtOvDRTvQyZuu7gZSiFRZ6Efx51k54Pc10cI3FsoEY5Hyrg6seCeQO6kKkTw6hcgUzBYTsBSlEd2F%2FKHXNpqNP6ZuuHQd87YpB89ipRmXCZ2XnnxGbMFpnjoxZ98mxvPtezLKmtEc5plTHj5QJ%2FV%2Bv6WuU8TgOzEsEarU4hpAh8sqQdR5xxC9OMXfzACUyCQFU7rYShWfVG3sL35l%2FV9lxnHWt4wS%2B0F4AW1Y3G%2F3%2F7mLHCX%2B82QFkLUvQwbY1Aac7ijtcNmO0%2Bq5J8I9SBD5n7AvwL5LhI4uMFfjQ45PBbIGbn9Td20hJletidbdheSnXuacuXSpNrMouFooyd0og72mJ0JkNhNOwqOjpF9F4fNtA5VlFTtlS4wbW8piJ4bGIvsE4Oh9%2BHxX6rw7lLvzilI2lV3crVvZZDu7BBKdrZBV8%2Faw05PDUNtLDpjgRCgEUnYwRxsfk9Bm%2FgQ3AAkEXTbO7c7sjCk57Ezx3Horx9MqwALL7afDq6qZ5FN1VVeW1QCjV3KwCoM%2B8ZH2BWQDrDKNMIo4XM0950F2k29Z%2FWFGN6I2iDtGQp5LRjH5wtQqrI6uZoI1uAJ%2BMg3XkBm%2Bdd5naSQxdXfinQ5E4ld5%2FNmwmZZ4WtaUvuoHLn0oYK1PFiRgLPgwxeqswgY6lwGTclXGhHEizP0YyZcmWTNZW%2BXaC8iiLRipyxqf4f69yi%2B5%2F4IV%2BR1cvf0e1sWX74eOhPG6o9UjVgxGxwOd5KwIvawyM2Io7wMK3l4%2FSPg12aTKjO420U1bXLlfB18vXXu0MLpfjXmgzNX9rxilCb6sdHPxry9e4ykwxCsKJ8d0xDb8tXKeyeRGje7yvchvcv7OjtoYbmo5&X-Amz-Signature=54a42c04791ee45c7e1fe2b61964238baaeed9d7ac16a2be520d2be60ced0f7d)
