### PR TITLE
Add ID mapping limitations documentation for DOCS-11

### DIFF
--- a/docs/client/Templates/_StableID.mdx
+++ b/docs/client/Templates/_StableID.mdx
@@ -5,6 +5,10 @@ the first time the SDK is initialized and is stored locally for all future sessi
 Unless storage is wiped (or app deleted), the stableID will not change.
 This allows us to run device level experiments and experiments when other user identifiable information is unavailable (Logged out users).
 
+:::note ID Mapping Limitations
+When using stableID for experiments, note that Cloud deployments cannot map between stableID and other ID types (like userID) for analysis. For advanced ID mapping capabilities, see [ID Mapping Capabilities](/experiments-plus/create-new#id-mapping-capabilities) or consider Statsig Warehouse Native.
+:::
+
 You can get the stableID for the current device with:
 
 <div>{props.getSnippet}</div>

--- a/docs/experiments-plus/create-new.md
+++ b/docs/experiments-plus/create-new.md
@@ -81,6 +81,16 @@ By default, experiments randomize users based on **User ID**. If you need to use
 
 Afterward, continue with the same steps described above to finish configuring the experiment.
 
+## ID Mapping Capabilities
+
+When running experiments, you may want to start with one ID type (like stableID for device-level targeting) but analyze results using events from another ID type (like userID for logged-in user metrics).
+
+**Warehouse Native**: Supports ID mapping between different identifier types (e.g., stableID to userID) through Entity Property Source configuration.
+
+**Cloud**: Currently does not support mapping between different ID types. Experiments started with stableID will only analyze events with stableID, and experiments started with userID will only analyze events with userID.
+
+For advanced ID mapping requirements, consider using Statsig Warehouse Native.
+
 ### Isolated Experiments
 
 If you want to create an experiment that excludes users exposed to other experiments, follow steps 1–4 from the "User-level Experiments" section. Then:

--- a/docs/metrics/101.md
+++ b/docs/metrics/101.md
@@ -20,6 +20,7 @@ This 101-level user guide steps through the basic concepts to help you set up es
 2. [Raw Events](/metrics/raw-events) 
     - [Types of Raw Events](/metrics/raw-events#types-of-raw-events)
     - [Unit Identifiers](/metrics/raw-events#unit-identifiers) required for raw events
+    - [ID Mapping Considerations](/experiments-plus/create-new#id-mapping-capabilities) for cross-ID analysis
     - [Ingesting Raw Events](/metrics/raw-events#ingesting-raw-events)
     - [Seeing Raw Events in the Statsig Console](/metrics/raw-events#raw-events-in-console)
 2. [Auto-generated Events](/metrics/metrics-from-events)

--- a/docs/statsig-warehouse-native/native-vs-cloud.md
+++ b/docs/statsig-warehouse-native/native-vs-cloud.md
@@ -92,6 +92,7 @@ If there's any confusion, or if a feature is critical for your evaluation, we're
 | Autocreate metric from SDK Events         | Cloud only for now   |
 | User Accounting Metrics (DAU, Stickiness) | Cloud only for now   |
 | Automated A/A Tests                       | Cloud only for now   |
+| Entity Property Source ID mapping         | WHN only             |
 
 ## Organization & Settings
 


### PR DESCRIPTION
# Add ID mapping limitations documentation for DOCS-11

This PR updates the Statsig documentation to clarify that ID mapping via Entity Property Source is only available in Statsig Warehouse Native and not in the Cloud product.

## Changes Made

1. **Updated comparison table** in `docs/statsig-warehouse-native/native-vs-cloud.md` to include "Entity Property Source ID mapping | WHN only" in the Metrics section

2. **Added ID Mapping Capabilities section** to `docs/experiments-plus/create-new.md` explaining the limitations:
   - Warehouse Native supports ID mapping between different identifier types through Entity Property Source configuration
   - Cloud does not support mapping between different ID types
   - Clear guidance for users with advanced ID mapping requirements

3. **Added cross-references** in key documentation locations:
   - Added note in `docs/client/Templates/_StableID.mdx` about ID mapping limitations with link to new section
   - Added "ID Mapping Considerations" link in `docs/metrics/101.md` Raw Events section

## Testing

- Documentation site builds successfully with `npm run dev`
- All internal links work correctly and navigate to the proper sections
- Content renders properly with correct formatting
- Cross-references appear in appropriate locations where users encounter ID type decisions

## Ticket

Addresses ticket DOCS-11 - customer feedback about missing ID mapping functionality in Cloud product dashboard.

**Link to Devin run**: https://app.devin.ai/sessions/c856816311f64eb9a07c7eb8fbe1756b

**Requested by**: craig@statsig.com
