### PR TITLE
Update enableIDLists requirement for segments with >1000 IDs

### DIFF
--- a/docs/server-core/elixir/_options.mdx
+++ b/docs/server-core/elixir/_options.mdx
@@ -27,7 +27,7 @@
     The URL Statsig should download specs from
 
   - **`enable_id_lists:`**: 
-    If ID list download should be enabled
+    Enable ID list download. **Required to be `true` when using segments with more than 1000 IDs.** See [ID List segments](/segments/add-id-list) for more details.
 
   - **`id_lists_url:`**: 
     The URL ID lists should be downloaded from

--- a/docs/server-core/java/_options.mdx
+++ b/docs/server-core/java/_options.mdx
@@ -32,7 +32,7 @@ When `true`, disables all network functions: event & exposure logging, spec down
   Maximum number of batches of events to hold in buffer to retry.
 
 - **`enableIDLists`**: `Optional[bool]`  
-  Enable/disable ID list functionality.
+  Enable/disable ID list functionality. **Required to be `true` when using segments with more than 1000 IDs.** See [ID List segments](/segments/add-id-list) for more details.
 
 - **`disableUserAgentParsing`** `Optional[bool]`
   Default false. If set to true, the SDK will NOT attempt to parse UserAgents (attached to the user object) into browserName, browserVersion, systemName, systemVersion, and appVersion at evaluation time, when needed for evaluation.

--- a/docs/server-core/node/_options.mdx
+++ b/docs/server-core/node/_options.mdx
@@ -23,7 +23,7 @@ The `StatsigOptions` class is used to specify optional parameters when initializ
   Default off. If turned on, SDK will not collect any loggings within the sessions, including custom events and config check exposure events.
 
 - **`enableIDLists`**: `Optional<bool>`  
-  Default off. You need to turn this on if you are using legacy Big ID Lists.
+  Default off. **Required to be `true` when using segments with more than 1000 IDs.** See [ID List segments](/segments/add-id-list) for more details.
 
 - **`disableUserAgentParsing`** `Optional[bool]`
   Default false. If set to true, the SDK will NOT attempt to parse UserAgents (attached to the user object) into browserName, browserVersion, systemName, systemVersion, and appVersion at evaluation time, when needed for evaluation.

--- a/docs/server-core/php/_options.mdx
+++ b/docs/server-core/php/_options.mdx
@@ -41,6 +41,9 @@ The `StatsigOptions` class is used to specify optional parameters when initializ
 - **`disable_user_agent_parsing`**: 
   Disables user agent parsing. Set to `true` to improve performance if device/browser-based targeting is not needed.
 
+- **`enable_id_lists`**: 
+  Enable/disable ID list functionality. **Required to be `true` when using segments with more than 1000 IDs.** See [ID List segments](/segments/add-id-list) for more details.
+
 ---
 
 ### Performance Recommendations

--- a/docs/server-core/python/_options.mdx
+++ b/docs/server-core/python/_options.mdx
@@ -29,7 +29,7 @@ The `statsig.initialize()` method takes an optional parameter `options` to custo
   Maximum number of events to queue before forcing a flush.
 
 - **`enable_id_lists`**: `Optional[bool]`  
-  Enable/disable BIG ID list functionality (IDList > 1000) 
+  Enable/disable ID list functionality. **Required to be `true` when using segments with more than 1000 IDs.** See [ID List segments](/segments/add-id-list) for more details.
 
 - **`disable_user_agent_parsing`** `Optional[bool]`
   Default false. If set to true, the SDK will NOT attempt to parse UserAgents (attached to the user object) into browserName, browserVersion, systemName, systemVersion, and appVersion at evaluation time, when needed for evaluation.

--- a/docs/server-core/rust/_options.mdx
+++ b/docs/server-core/rust/_options.mdx
@@ -14,7 +14,7 @@ External data store for Statsig values.
   When `true`, disables all network functions: event & exposure logging, spec downloads, and ID List downloads. Formerly called "localMode".
 
 - **`enable_id_lists`**: Option\<bool\>
-  Enable/disable ID list functionality.
+  Enable/disable ID list functionality. **Required to be `true` when using segments with more than 1000 IDs.** See [ID List segments](/segments/add-id-list) for more details.
 
 - **`disable_user_agent_parsing`** `Optional[bool]`
   Default false. If set to true, the SDK will NOT attempt to parse UserAgents (attached to the user object) into browserName, browserVersion, systemName, systemVersion, and appVersion at evaluation time, when needed for evaluation.


### PR DESCRIPTION
# Update enableIDLists requirement for segments with >1000 IDs

## Summary
Updated all core server-side SDK options documentation to clarify that `enableIDLists` must be set to `true` in `StatsigOptions` when using segments with more than 1000 IDs.

## Changes Made
- **Python SDK**: Updated `enable_id_lists` parameter description in `/docs/server-core/python/_options.mdx`
- **Java SDK**: Updated `enableIDLists` parameter description in `/docs/server-core/java/_options.mdx`
- **Rust SDK**: Updated `enable_id_lists` parameter description in `/docs/server-core/rust/_options.mdx`
- **Node.js SDK**: Updated `enableIDLists` parameter description in `/docs/server-core/node/_options.mdx`
- **Elixir SDK**: Updated `enable_id_lists` parameter description in `/docs/server-core/elixir/_options.mdx`
- **PHP SDK**: Added new `enable_id_lists` parameter to `/docs/server-core/php/_options.mdx`

## Documentation Updates
All updates include consistent messaging:
- **Required to be `true` when using segments with more than 1000 IDs.**
- Reference to [ID List segments](/segments/add-id-list) for technical details

## Verification
- ✅ Documentation builds successfully (`npm run build` passes)
- ✅ All changes use consistent wording across SDKs
- ✅ Links to existing segment documentation work correctly

## Context
This addresses customer support requests about the requirement to enable ID lists functionality when using segments with more than 1000 IDs. The documentation now clearly states this requirement across all core server-side SDKs.

---

**Link to Devin run**: https://app.devin.ai/sessions/0cfb9261298e4c9db63cd85eb852c01c  
**Requested by**: weihao@statsig.com
