### PR TITLE
Update Java Core docs to show StatsigUser creation examples

### DIFF
--- a/docs/server-core/java/_checkGate.mdx
+++ b/docs/server-core/java/_checkGate.mdx
@@ -11,6 +11,7 @@ import TabItem from "@theme/TabItem";
   <TabItem value="java">
 
 ```java
+StatsigUser user = new StatsigUser.Builder().setUserID("user-123").build();
 boolean isFeatureOn = statsig.checkGate(user, "example_gate");
 ```
 
@@ -18,6 +19,7 @@ boolean isFeatureOn = statsig.checkGate(user, "example_gate");
   <TabItem value="kotlin">
 
 ```kotlin
+val user = StatsigUser.Builder().setUserID("user-123").build()
 val isFeatureOn = statsig.checkGate(user, "example_gate")
 ```
 

--- a/docs/server-core/java/_getConfig.mdx
+++ b/docs/server-core/java/_getConfig.mdx
@@ -19,6 +19,7 @@ import TabItem from "@theme/TabItem";
   <TabItem value="java">
 
 ```java
+StatsigUser user = new StatsigUser.Builder().setUserID("user-123").build();
 DynamicConfig config = statsig.getDynamicConfig(user, "awesome_product_details");
 ```
 
@@ -26,6 +27,7 @@ DynamicConfig config = statsig.getDynamicConfig(user, "awesome_product_details")
   <TabItem value="kotlin">
 
 ```kotlin
+val user = StatsigUser.Builder().setUserID("user-123").build()
 val config = statsig.getDynamicConfig(user, "awesome_product_details")
 ```
 

--- a/docs/server-core/java/_getExperiment.mdx
+++ b/docs/server-core/java/_getExperiment.mdx
@@ -11,10 +11,12 @@ import TabItem from "@theme/TabItem";
   <TabItem value="java">
 
 ```java
+StatsigUser user = new StatsigUser.Builder().setUserID("user-123").build();
 Layer layer = statsig.getLayer(user, "layer_name");
 ```
 
 ```java
+StatsigUser user = new StatsigUser.Builder().setUserID("user-123").build();
 Experiment experiment = statsig.getExperiment(user, "sample_exp");
 ```
 
@@ -22,10 +24,12 @@ Experiment experiment = statsig.getExperiment(user, "sample_exp");
   <TabItem value="kotlin">
 
 ```kotlin
+val user = StatsigUser.Builder().setUserID("user-123").build()
 val layer = statsig.getLayer(user, "layer_name")
 ```
 
 ```kotlin
+val user = StatsigUser.Builder().setUserID("user-123").build()
 val experiment = statsig.getExperiment(user, "sample_exp")
 ```
 

--- a/docs/server-core/java/_getFeatureGate.mdx
+++ b/docs/server-core/java/_getFeatureGate.mdx
@@ -11,13 +11,15 @@ import TabItem from "@theme/TabItem";
   <TabItem value="java">
 
 ```java
- FeatureGate gate = statsig.getFeatureGate(user, "example_gate");
+StatsigUser user = new StatsigUser.Builder().setUserID("user-123").build();
+FeatureGate gate = statsig.getFeatureGate(user, "example_gate");
 ```
 
   </TabItem>
   <TabItem value="kotlin">
 
 ```kotlin
+val user = StatsigUser.Builder().setUserID("user-123").build()
 val gate = statsig.getFeatureGate(user, "example_gate")
 ```
 

--- a/docs/server-core/java/_paramStores.mdx
+++ b/docs/server-core/java/_paramStores.mdx
@@ -14,6 +14,7 @@ import TabItem from "@theme/TabItem";
 
 ```java
 // Get a Parameter Store by name
+StatsigUser user = new StatsigUser.Builder().setUserID("user-123").build();
 ParameterStore parameterStore = statsig.getParameterStore(user, "my_parameter_store");
 ```
 
@@ -22,6 +23,7 @@ ParameterStore parameterStore = statsig.getParameterStore(user, "my_parameter_st
 
 ```kotlin
 // Get a Parameter Store by name
+val user = StatsigUser.Builder().setUserID("user-123").build()
 val parameterStore = statsig.getParameterStore(user, "my_parameter_store")
 ```
 
@@ -102,6 +104,7 @@ You can also use the Statsig instance directly:
   <TabItem value="java">
 
 ```java
+StatsigUser user = new StatsigUser.Builder().setUserID("user-123").build();
 String stringValue = statsig.getStringFromParameterStore(user, "my_parameter_store", "string_param", "default_value");
 ```
 
@@ -109,6 +112,7 @@ String stringValue = statsig.getStringFromParameterStore(user, "my_parameter_sto
   <TabItem value="kotlin">
 
 ```kotlin
+val user = StatsigUser.Builder().setUserID("user-123").build()
 val stringValue = statsig.getStringFromParameterStore(user, "my_parameter_store", "string_param", "default_value")
 ```
 

--- a/docs/server-core/java/_sharedInstance.mdx
+++ b/docs/server-core/java/_sharedInstance.mdx
@@ -7,6 +7,7 @@ statsig.initialize().get();
 
 // Access the shared instance from anywhere in your code
 Statsig sharedStatsig = Statsig.shared();
+StatsigUser user = new StatsigUser.Builder().setUserID("user-123").build();
 boolean isFeatureEnabled = sharedStatsig.checkGate(user, "feature_name");
 
 // Check if a shared instance exists


### PR DESCRIPTION

# Update Java Core docs to show StatsigUser creation examples

## Summary

Updated Java Core SDK documentation to consistently show `StatsigUser` object creation in all method examples. Previously, examples like `statsig.checkGate(user, "example_gate")` referenced a `user` object without showing how to create it, which could confuse developers trying to implement the SDK.

**Files Updated:**
- `_checkGate.mdx` - Added user creation to gate checking examples
- `_getExperiment.mdx` - Added user creation to experiment and layer examples  
- `_getConfig.mdx` - Added user creation to dynamic config examples
- `_getFeatureGate.mdx` - Added user creation to feature gate examples
- `_paramStores.mdx` - Added user creation to parameter store examples
- `_sharedInstance.mdx` - Added user creation to shared instance examples

All changes follow the established pattern from `_logEvent.mdx` and match the builder pattern used in the actual Java SDK implementation.

## Review & Testing Checklist for Human

- [ ] **Verify StatsigUser.Builder() pattern accuracy** - Confirm the `new StatsigUser.Builder().setUserID("user-123").build()` pattern matches the actual Java SDK API
- [ ] **Check syntax correctness** - Verify both Java and Kotlin examples compile without syntax errors
- [ ] **Test documentation rendering** - Ensure all code blocks render properly in the documentation site
- [ ] **Validate consistency** - Confirm all 6 updated files use the same user creation pattern consistently

**Recommended Test Plan:**
1. Run `npm run build` to ensure documentation builds successfully
2. Run `npm run dev` and navigate to Java Core SDK documentation pages
3. Verify all code examples display correctly with proper syntax highlighting
4. Cross-reference examples with the actual Java SDK implementation

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Java Core Documentation"
        checkGate["docs/server-core/java/<br/>_checkGate.mdx"]:::major-edit
        getExperiment["docs/server-core/java/<br/>_getExperiment.mdx"]:::major-edit
        getConfig["docs/server-core/java/<br/>_getConfig.mdx"]:::major-edit
        getFeatureGate["docs/server-core/java/<br/>_getFeatureGate.mdx"]:::major-edit
        paramStores["docs/server-core/java/<br/>_paramStores.mdx"]:::major-edit
        sharedInstance["docs/server-core/java/<br/>_sharedInstance.mdx"]:::major-edit
    end
    
    subgraph "Reference Files"
        logEvent["docs/server-core/java/<br/>_logEvent.mdx"]:::context
        javaCore["docs/server-core/<br/>java-core.mdx"]:::context
        statsigUser["docs/server-core/java/<br/>_statsigUser.mdx"]:::context
    end
    
    subgraph "SDK Implementation"
        javaSDK["statsig-java/src/main/java/<br/>com/statsig/StatsigUser.java"]:::context
    end
    
    logEvent -->|"Pattern<br/>Reference"| checkGate
    logEvent -->|"Pattern<br/>Reference"| getExperiment
    logEvent -->|"Pattern<br/>Reference"| getConfig
    javaSDK -->|"API<br/>Reference"| checkGate
    javaCore -->|"Imports"| checkGate
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- Changes maintain consistency with existing `_logEvent.mdx` which already showed proper user creation
- All examples use consistent user ID "user-123" across documentation
- Both Java and Kotlin examples updated to maintain language parity
- Documentation builds successfully with no errors
- Session requested by @weihao-statsig
- Link to Devin run: https://app.devin.ai/sessions/32df0b3e67644a279b3d74e23924cb95
