### PR TITLE
redirect from /feature-gates/overview to /feature-flags/overview

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -146,7 +146,7 @@ const config: Config = {
         redirects: [
           {
             from: "/guides/guides/feature-gates",
-            to: "/guides/feature-flags"
+            to: "/guides/feature-flags",
           },
           {
             from: "/feature-flags/create-new",
@@ -154,7 +154,7 @@ const config: Config = {
           },
           {
             from: "/feature-flags/add-rule",
-            to: "/feature-flags/create#add-a-rule-to-your-feature-gate"
+            to: "/feature-flags/create#add-a-rule-to-your-feature-gate",
           },
           {
             from: "/stats-engine/offlineaa",
@@ -369,6 +369,10 @@ const config: Config = {
             from: "/feature-gates/working-with",
           },
           {
+            to: "/feature-flags/overview",
+            from: "/feature-gates/overview",
+          },
+          {
             to: "/feature-flags/create-new",
             from: "/feature-gates/create-new",
           },
@@ -465,7 +469,7 @@ const config: Config = {
       contextualSearch: true,
 
       searchParameters: {
-        facetFilters: []
+        facetFilters: [],
       },
 
       insights: true,
@@ -480,26 +484,26 @@ const config: Config = {
       },
       items: [
         {
-          type: 'doc',
-          position: 'left',
-          docId: 'getting-started',
-          sidebarId: 'product-docs',
-          label: 'Product Docs',
-          id: 'product-docs', //don't edit this without rerunning algolia scraper
+          type: "doc",
+          position: "left",
+          docId: "getting-started",
+          sidebarId: "product-docs",
+          label: "Product Docs",
+          id: "product-docs", //don't edit this without rerunning algolia scraper
         },
         {
-          type: 'docSidebar',
-          position: 'left',
-          sidebarId: 'warehouse',
-          label: 'Warehouse Native',
-          id: 'warehouse', //don't edit this without rerunning algolia scraper
+          type: "docSidebar",
+          position: "left",
+          sidebarId: "warehouse",
+          label: "Warehouse Native",
+          id: "warehouse", //don't edit this without rerunning algolia scraper
         },
         {
-          type: 'docSidebar',
-          position: 'left',
-          sidebarId: 'api',
-          label: 'SDKs & APIs',
-          id: 'sdk-api', //don't edit this without rerunning algolia scraper
+          type: "docSidebar",
+          position: "left",
+          sidebarId: "api",
+          label: "SDKs & APIs",
+          id: "sdk-api", //don't edit this without rerunning algolia scraper
         },
         {
           type: "search",


### PR DESCRIPTION
## Description

currently if you google "feature gates statsig" it comes up with docs.statsig.com/feature-gates/overview which 404s. Added a redirect

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!