### PR TITLE
Add support for linux-musl-arm64 and linux-musl-x86_64 architectures in Java Core SDK

### DIFF
--- a/docs/server-core/java/_supported_combinations.mdx
+++ b/docs/server-core/java/_supported_combinations.mdx
@@ -3,6 +3,8 @@
 | `java-core` | Platform-independent Java core, **ALWAYS ADD THIS** (not needed if using uber JAR) | `implementation 'com.statsig:javacore:X.X.X'`  |
 | `uber` | Self-contained JAR with both core library and native libraries for Linux (x86_64, arm64), macOS (x86_64, arm64), and Windows (x86_64) (available since version 0.4.0, if used, no other dependencies needed) | `implementation 'com.statsig:javacore:X.X.X:uber'` |
 | `linux-gnu-x86_64` | Linux GNU (Intel/AMD 64-bit, x86_64) | `implementation 'com.statsig:javacore:X.X.X:linux-gnu-x86_64'` |
+| `linux-musl-arm64` | Linux musl (ARM64) (available since version 0.6.1) | `implementation 'com.statsig:javacore:X.X.X:linux-musl-arm64'` |
+| `linux-musl-x86_64` | Linux musl (Intel/AMD 64-bit, x86_64) (available since version 0.6.1) | `implementation 'com.statsig:javacore:X.X.X:linux-musl-x86_64'` |
 | `macos-arm64` | macOS (Apple Silicon/ARM64) | `implementation 'com.statsig:javacore:X.X.X:macos-arm64'` |
 | `macos-x86_64` | macOS (Intel/x86_64 or AMD64) | `implementation 'com.statsig:javacore:X.X.X:macos-x86_64'` |
 | `windows-x86_64` | Windows (Intel/AMD 64-bit architecture, x86_64) | `implementation 'com.statsig:javacore:X.X.X:windows-x86_64'` |

--- a/docs/server-core/java/_supported_combinations.mdx
+++ b/docs/server-core/java/_supported_combinations.mdx
@@ -3,8 +3,8 @@
 | `java-core` | Platform-independent Java core, **ALWAYS ADD THIS** (not needed if using uber JAR) | `implementation 'com.statsig:javacore:X.X.X'`  |
 | `uber` | Self-contained JAR with both core library and native libraries for Linux (x86_64, arm64), macOS (x86_64, arm64), and Windows (x86_64) (available since version 0.4.0, if used, no other dependencies needed) | `implementation 'com.statsig:javacore:X.X.X:uber'` |
 | `linux-gnu-x86_64` | Linux GNU (Intel/AMD 64-bit, x86_64) | `implementation 'com.statsig:javacore:X.X.X:linux-gnu-x86_64'` |
-| `linux-musl-arm64` | Linux musl (ARM64) (available since version 0.6.1) | `implementation 'com.statsig:javacore:X.X.X:linux-musl-arm64'` |
-| `linux-musl-x86_64` | Linux musl (Intel/AMD 64-bit, x86_64) (available since version 0.6.1) | `implementation 'com.statsig:javacore:X.X.X:linux-musl-x86_64'` |
+| `linux-musl-arm64` | Linux musl/Alpine (ARM64) (available since version 0.6.1) | `implementation 'com.statsig:javacore:X.X.X:linux-musl-arm64'` |
+| `linux-musl-x86_64` | Linux musl/Alpine (Intel/AMD 64-bit, x86_64) (available since version 0.6.1) | `implementation 'com.statsig:javacore:X.X.X:linux-musl-x86_64'` |
 | `macos-arm64` | macOS (Apple Silicon/ARM64) | `implementation 'com.statsig:javacore:X.X.X:macos-arm64'` |
 | `macos-x86_64` | macOS (Intel/x86_64 or AMD64) | `implementation 'com.statsig:javacore:X.X.X:macos-x86_64'` |
 | `windows-x86_64` | Windows (Intel/AMD 64-bit architecture, x86_64) | `implementation 'com.statsig:javacore:X.X.X:windows-x86_64'` |


### PR DESCRIPTION

# Add support for linux-musl-arm64 and linux-musl-x86_64 architectures in Java Core SDK

## Summary

Updated the Java Core SDK documentation to include support for two new Linux musl-based architectures:
- `linux-musl-arm64` - Linux musl (ARM64)
- `linux-musl-x86_64` - Linux musl (Intel/AMD 64-bit, x86_64)

Both architectures are documented as available since version 0.6.1. The changes follow the existing table format and dependency pattern used for other supported OS/architecture combinations.

## Review & Testing Checklist for Human

- [ ] **Verify version accuracy**: Confirm that `linux-musl-arm64` and `linux-musl-x86_64` artifacts actually exist and are available starting from version 0.6.1
- [ ] **Test dependency strings**: Verify the Maven dependency strings `implementation 'com.statsig:javacore:X.X.X:linux-musl-arm64'` and `implementation 'com.statsig:javacore:X.X.X:linux-musl-x86_64'` work correctly
- [ ] **Check table rendering**: Review the live documentation site to ensure the markdown table displays correctly with proper formatting and alignment

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Java Core Documentation"
        JavaCore["docs/server-core/<br/>java-core.mdx"]:::context
        SupportedCombos["docs/server-core/java/<br/>_supported_combinations.mdx"]:::major-edit
    end
    
    subgraph "Build System"
        DocusaurusBuild["npm run build"]:::context
    end
    
    JavaCore -->|imports| SupportedCombos
    SupportedCombos -->|compiled by| DocusaurusBuild
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This change was requested by @weihao-statsig via Slack to document new musl-based Linux architecture support
- The table entry placement follows logical ordering (after `linux-gnu-x86_64`, before `macos-arm64`)
- Documentation build completed successfully with no errors related to these changes
- Session URL: https://app.devin.ai/sessions/41caf29229444c20a95ee4dcf64e97e7
