### PR TITLE
Update _options.mdx

### DIFF
--- a/docs/server/go/_options.mdx
+++ b/docs/server/go/_options.mdx
@@ -82,7 +82,7 @@ type GCIROptions struct {
 
 - **Overrides**: default null
   - A pointer to values to override in the response.
-  - When specified, the SDK will return the overriden values of Feature Gates, Dynamic Configs, and Layers.
+  - When specified, the SDK will return the overridden values of Feature Gates, Dynamic Configs, and Layers.
   - Possible values include FeatureGate, DynamicConfigs, and Layers.
   - If not specified, the SDK will return the normal values of feature gates, layers, and dynamic configs without overrides.
 


### PR DESCRIPTION
docs change to add gcir override options for go sdk

<img width="839" height="378" alt="image" src="https://github.com/user-attachments/assets/41078446-e225-4fbb-9ec0-1618ffd11164" />

<img width="820" height="337" alt="image" src="https://github.com/user-attachments/assets/70afba95-2067-413e-9a3e-501ba30d8ffc" />
