### PR TITLE
Add NODE CORE example to persistent assignment documentation

### DIFF
--- a/docs/server/concepts/persistent_assignment.mdx
+++ b/docs/server/concepts/persistent_assignment.mdx
@@ -19,7 +19,7 @@ The persistent storage adapter allows you to plug in your own storage solution t
 The storage interface consists of just a `load` and `save` API for read/write operations.
 
 :::info
-Currently only supported in `Go`, `Ruby`, `Legacy Node`, `Node`, `Kotlin`, `.Net`, `Python`
+Currently only supported in `Go`, `Ruby`, `Legacy Node`, `NODE CORE`, `Node`, `Kotlin`, `.Net`, `Python`
 :::
 
 ### Persistent Storage Logic
@@ -39,6 +39,7 @@ Currently only supported in `Go`, `Ruby`, `Legacy Node`, `Node`, `Kotlin`, `.Net
   defaultValue="node"
   values={[
     {label: 'Node JS', value: 'node'},
+    {label: 'NODE CORE', value: 'node-core'},
     {label: 'Kotlin', value: 'kotlin'},
   ]}>
   <TabItem value="kotlin">
@@ -62,6 +63,16 @@ const options: GetExperimentOptions = {
 
 ````
   </TabItem>
+  <TabItem value="node-core">
+```ts
+const options: GetExperimentOptions = {
+  ...
+  persistentAssignmentOptions: {
+    enforceTargeting: true,
+  }
+}
+```
+  </TabItem>
 </Tabs>
 
 ### Example usage
@@ -71,6 +82,7 @@ const options: GetExperimentOptions = {
   defaultValue="ruby"
   values={[
     {label: 'Python (Python Core)', value: 'python-core'},
+    {label: 'NODE CORE', value: 'node-core'},
     {label: 'Node JS', value: 'node'},
     {label: 'Kotlin', value: 'kotlin'},
     {label: 'Ruby', value: 'ruby'},
@@ -115,6 +127,57 @@ user = StatsigUser("a-user")
 exp = statsig.get_experiment(StatsigUser("a-user"), ExperimentEvaluationOptions(user_persisted_values= PersistentStorage.get_user_persisted_value(user, "user_id")))
 print(f"{exp.group_name}") # control
 ````
+  </TabItem>
+  <TabItem value="node-core">
+```typescript
+import { Statsig, StatsigUser, StatsigOptions, PersistentStorage, StickyValues, UserPersistedValues } from '@statsig/statsig-node-core';
+
+class MyPersistentStorage implements PersistentStorage {
+  private storage = new Map<string, UserPersistedValues>();
+
+  load(key: string): UserPersistedValues | null {
+    return this.storage.get(key) || null;
+  }
+
+  save(key: string, config_name: string, data: StickyValues): void {
+    const existing = this.storage.get(key) || {};
+    existing[config_name] = data;
+    this.storage.set(key, existing);
+  }
+
+  delete(key: string, config_name: string): void {
+    const existing = this.storage.get(key);
+    if (existing) {
+      delete existing[config_name];
+      this.storage.set(key, existing);
+    }
+  }
+}
+
+const options: StatsigOptions = {
+  persistentStorage: new MyPersistentStorage()
+};
+await Statsig.initialize('secret-key', options);
+
+const persistedUser: StatsigUser = { userID: 'test-123' };
+let exp = Statsig.getExperiment(
+  persistedUser,
+  'active_experiment',
+  { 
+    userPersistedValues: Statsig.getUserPersistedValues(persistedUser, 'userID')
+  }
+);
+console.log(exp.getGroupName()); // 'Control'
+
+exp = Statsig.getExperiment(
+  { userID: 'unknown' },
+  'active_experiment',
+  { 
+    userPersistedValues: Statsig.getUserPersistedValues(persistedUser, 'userID')
+  }
+);
+console.log(exp.getGroupName()); // 'Control'
+```
   </TabItem>
   
   <TabItem value="kotlin">


### PR DESCRIPTION
## Description

Added NODE CORE example to the persistent assignment documentation page following the same pattern as existing SDK examples. This addresses the missing NODE CORE documentation in the persistent storage section.

### Changes:
- Added NODE CORE to the supported SDKs list 
- Added NODE CORE tab to the persistent assignment options section
- Added NODE CORE tab with complete implementation example to the main examples section
- Used NODE CORE PersistentStorage interface with load/save/delete methods
- Followed same pattern as other SDK examples with initialization, user creation, and experiment evaluation

![Screenshot showing NODE CORE tab working](file:///home/ubuntu/screenshots/localhost_3000_205200.png)

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any  
- [x] I've updated screenshots affected by this change, if any

## Review Focus Areas

**⚠️ Please verify these critical items:**

1. **NODE CORE API Accuracy**: Confirm the imports, method names, and interface implementation match the actual `@statsig/statsig-node-core` SDK
   - Especially verify `getUserPersistedValues` method exists and has correct signature
   - Check that `PersistentStorage`, `StickyValues`, `UserPersistedValues` types are imported correctly

2. **Code Example Correctness**: Ensure the TypeScript example compiles and follows NODE CORE patterns
   - Verify the `StatsigOptions` configuration with `persistentStorage` property
   - Check the `getExperiment` method signature and parameters

3. **Consistency**: Confirm the example follows the same user IDs, experiment names, and flow as other SDK examples for consistency

## Testing Done

- ✅ Local dev server runs without build errors
- ✅ Page renders correctly with NODE CORE tabs visible
- ✅ Tab switching functionality works properly  
- ✅ Code syntax highlighting displays correctly
- ✅ Documentation build completes successfully

---

**Link to Devin run**: https://app.devin.ai/sessions/8b8be41b145b49f0b082f2c1a9fc6650

**Requested by**: @weihao-statsig

## Questions?

Reach out to Brock or Tore on Slack!