### PR TITLE
Add signup CTA experiment

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -510,9 +510,7 @@ const config: Config = {
           type: "search",
         },
         {
-          type: "html",
-          value:
-            "<button class=\"signupCTA CTA\" onclick=\"window.open('https://console.statsig.com', '_blank').focus();\">Get Started</button>",
+          type: "custom-signupCTA",
         },
       ],
     },

--- a/src/components/NavbarItems/SignupCTA/index.d.ts
+++ b/src/components/NavbarItems/SignupCTA/index.d.ts
@@ -1,0 +1,4 @@
+import React from 'react';
+declare function SignupCTA({}: {}): JSX.Element;
+declare const _default: React.MemoExoticComponent<typeof SignupCTA>;
+export default _default;

--- a/src/components/NavbarItems/SignupCTA/index.js
+++ b/src/components/NavbarItems/SignupCTA/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
+const SignupCTA = () => (
+  <BrowserOnly>
+    {() => {
+      const statsig = window.Statsig.StatsigClient.instance();
+      const ctaExp = statsig?.getExperiment('docs_signup_cta');
+      const url = ctaExp?.get('url') ?? 'https://console.statsig.com';
+      const cta = ctaExp?.get('cta') ?? 'Get Started';
+      return (
+        <a className="navbar__item" href={url} target="_blank">
+          <button className="signupCTA CTA">{cta}</button>
+        </a>
+      );
+    }}
+  </BrowserOnly>
+);
+export default React.memo(SignupCTA);

--- a/src/theme/NavbarItem/ComponentTypes.js
+++ b/src/theme/NavbarItem/ComponentTypes.js
@@ -1,7 +1,9 @@
 import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
 import WarehouseToggle from '@site/src/components/NavbarItems/WarehouseToggle';
+import SignupCTA from '@site/src/components/NavbarItems/SignupCTA';
 
 export default {
   ...ComponentTypes,
   'custom-warehouseToggle': WarehouseToggle,
+  'custom-signupCTA': SignupCTA,
 };


### PR DESCRIPTION
## Description

Added code to support an experiment on the signup CTA to try changing the wording and linking directly to the sign up page

<img width="288" height="113" alt="image" src="https://github.com/user-attachments/assets/9cfd59e7-31cf-4f20-83ce-ab87ded9ef29" />
<img width="230" height="102" alt="image" src="https://github.com/user-attachments/assets/bd5b9241-4c81-4169-aa84-115af61280de" />

## Best practice checklist

- [X] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [X] I've deleted and redirected old pages to this one, if any
- [X] I've updated links affected by this change, if any
- [X] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!