### PR TITLE
Update ingest.md

### DIFF
--- a/docs/metrics/ingest.md
+++ b/docs/metrics/ingest.md
@@ -9,7 +9,7 @@ last_update:
 ---
 ## Ingesting Precomputed [Metrics](/metrics)
 
-Statsig can ingest your precomputed product and business metrics using our data warehouse connector (Metrics Imports).  Integrations like [Snowflake](/integrations/data-imports/snowflake), [BigQuery](/integrations/data-imports/bigquery) and [Redshift](/integrations/data-imports/redshift) are supported.
+Statsig can ingest your precomputed product and business metrics using our data warehouse connector (Metrics Imports).  Integrations like [Snowflake](data-warehouse-ingestion/snowflake), [BigQuery](/data-warehouse-ingestion/bigquery/) and [Redshift](/data-warehouse-ingestion/redshift/) and [more](/data-warehouse-ingestion/introduction) are supported.
 
 Statsig does not automatically process these metrics until you mark them as ready, as it's possible you might land data out of order. Once you are finished loading data for a period, you mark the data as ready by hitting the `mark_data_ready` API:
 


### PR DESCRIPTION
The links to the integrations for the specific warehouses are flagged as deprecated (Census and Fivetran based integration), so linking out to the new direct to warehouse connection.

## Description

Brief summary or screenshot of your changes

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!