### PR TITLE
Remove .git extension from iOS installation URLs

### DIFF
--- a/docs/client/iOS/_install.mdx
+++ b/docs/client/iOS/_install.mdx
@@ -13,7 +13,7 @@ To use the SDK in your project, you must add Statsig as a dependency.
   <TabItem value="spm">
 
 In your Xcode, select File > Swift Packages > Add Package Dependency
-and enter the URL https://github.com/statsig-io/statsig-kit.git.
+and enter the URL https://github.com/statsig-io/statsig-kit.
 
 You can also include it directly in your project's Package.swift. Find out the latest release version on our [GitHub page](https://github.com/statsig-io/statsig-kit/releases).
 
@@ -21,7 +21,7 @@ You can also include it directly in your project's Package.swift. Find out the l
 //...
 dependencies: [
     // see the latest version on https://github.com/statsig-io/statsig-kit/releases
-    .package(url: "https://github.com/statsig-io/statsig-kit.git", .upToNextMinor("X.Y.Z")),
+    .package(url: "https://github.com/statsig-io/statsig-kit", .upToNextMinor("X.Y.Z")),
 ],
 //...
 targets: [

--- a/docs/client/iOS/repo-migration-guide.mdx
+++ b/docs/client/iOS/repo-migration-guide.mdx
@@ -28,13 +28,13 @@ Given that this issue was blocking some customers from using Statsig, we decided
 2. Choose your project under the "Project" section of the second sidebar
 3. Choose the "Package Dependencies" tab on the top
 4. Find Statsig's SDK row
-5. On the Location column, replace `https://github.com/statsig-io/ios-sdk.git` with `https://github.com/statsig-io/statsig-kit.git` 
+5. On the Location column, replace `https://github.com/statsig-io/ios-sdk.git` with `https://github.com/statsig-io/statsig-kit` 
 
 ### Packages using Package.swift
 
 > **Required Migration**: GitHub's repo redirect doesn't work for packages using Package.swift
 
 1. Open your Package.swift file
-2. Replace `https://github.com/statsig-io/ios-sdk.git` with `https://github.com/statsig-io/statsig-kit.git`
+2. Replace `https://github.com/statsig-io/ios-sdk.git` with `https://github.com/statsig-io/statsig-kit`
 3. Replace `ios-sdk` with `statsig-kit`
 4. Build your project. If you get an error, build again at least once.


### PR DESCRIPTION
## Description

Removes the `.git` extension from iOS installation URLs to fix Xcode compatibility issues. Customer feedback indicated that "Xcode won't find the repo if the URL has the .git extension" when trying to add Statsig's iOS SDK as a Swift Package dependency.

**Changes made:**
- Updated Swift Package Manager installation instructions in iOS documentation
- Updated Package.swift example code snippets 
- Updated iOS repo migration guide instructions
- Updated console onboarding flow URLs
- Updated CocoaPods spec source URL

**Files affected:**
- `docs/client/iOS/_install.mdx` - Installation instructions and Package.swift examples
- `docs/client/iOS/repo-migration-guide.mdx` - Migration guide URLs 
- `console/client/components/console/core/onboarding/SDKInstructions/client/OnboardingiOSInstructions.tsx` - Console onboarding
- `Statsig.podspec` - CocoaPods specification (ios-client-sdk repo)

## Human Review Checklist

- [ ] **Verify URLs work in Xcode** - Test that `https://github.com/statsig-io/statsig-kit` (without `.git`) can be successfully added as a Swift Package dependency in Xcode
- [ ] **Check for missed locations** - Search for any other documentation, README files, or configuration that might reference the old URLs with `.git` extensions
- [ ] **Test onboarding flow** - Verify the console onboarding instructions work correctly for new iOS developers
- [ ] **Validate CocoaPods spec** - Ensure the updated `.podspec` file still works correctly for CocoaPods installation
- [ ] **Cross-reference with customer feedback** - Confirm these changes address the specific Xcode compatibility issue reported

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!

---

**Link to Devin run:** https://app.devin.ai/sessions/d59b5668a80e4afc9fa3bb33dcf62e4e  
**Requested by:** Andre Terron (@andre-statsig)