### PR TITLE
Fix Statsig environment detection for Netlify previews

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -43,7 +43,8 @@ const config: Config = {
   plugins: [
     function statsig() {
       const isProd = process.env.NODE_ENV === "production";
-      const tier = isProd ? "production" : "development";
+      const isNetlifyPreview = process.env.CONTEXT === "deploy-preview" || process.env.CONTEXT === "branch-deploy";
+      const tier = isProd && !isNetlifyPreview ? "production" : "development";
       return {
         name: "docusaurus-plugin-statsig",
         getClientModules() {


### PR DESCRIPTION
## Description

Fixes Statsig SDK environment detection to properly set the environment to "development" for Netlify preview deployments and localhost, instead of always defaulting to "production" when unset.

**Problem**: The docs site's Statsig integration was only checking `NODE_ENV` to determine the environment tier. This meant Netlify preview deployments (which run with `NODE_ENV=production`) were incorrectly using the "production" environment, potentially polluting production analytics with preview traffic.

**Solution**: Added detection for Netlify's `CONTEXT` environment variable to identify preview deployments:
- `CONTEXT=deploy-preview` or `CONTEXT=branch-deploy` → use "development" environment  
- `NODE_ENV=production` AND `CONTEXT=production` (or undefined) → use "production" environment
- Local development (`NODE_ENV≠production`) → use "development" environment

**Testing**: Verified locally that `window.statsigTier` is correctly set to "development" in the development environment.

## Changes

- Modified the `statsig()` plugin function in `docusaurus.config.ts` to check both `NODE_ENV` and `CONTEXT` environment variables
- Added logic to detect Netlify preview contexts (`deploy-preview`, `branch-deploy`) and set them to use "development" environment

## Human Review Checklist

- [ ] **Logic verification**: Confirm the boolean logic `isProd && !isNetlifyPreview ? "production" : "development"` correctly handles all deployment scenarios
- [ ] **Environment variable availability**: Verify that Netlify's `CONTEXT` environment variable is reliably available during builds and preview deployments
- [ ] **Netlify preview testing**: Test in an actual Netlify preview deployment to ensure `window.statsigTier` is set to "development"
- [ ] **Production safety**: Confirm this change doesn't break production Statsig analytics or affect production environment detection
- [ ] **Documentation**: Consider if this change needs to be documented anywhere for future reference

## Risk Assessment

⚠️ **Medium Risk**: This change affects how the Statsig environment is determined across all deployments. While the logic appears sound, it hasn't been tested in actual Netlify preview environments where the `CONTEXT` variable would be set.

## Questions?

Reach out to Brock or Tore on Slack!

---
**Link to Devin run**: https://app.devin.ai/sessions/23e92178c92640b7a9e78c8c781d6fcf  
**Requested by**: @tore-statsig