### PR TITLE
Add Alpine Docker requirements for Java Core SDK

### DIFF
--- a/docs/server-core/java/_install.mdx
+++ b/docs/server-core/java/_install.mdx
@@ -160,6 +160,45 @@ For Linux with x86_64 architecture, add the following to build.gradle:
 
 </details>
 
+## Docker Considerations
+
+### Alpine Linux / musl-based Containers
+
+When using Alpine Linux or other musl-based Docker containers, you need to install additional compatibility packages for the native libraries to work properly.
+
+Add the following to your Dockerfile:
+
+```dockerfile
+RUN apk add --no-cache libgcc gcompat
+```
+
+**Example Dockerfile:**
+
+```dockerfile
+FROM alpine:latest
+
+# Install Java and required compatibility packages
+RUN apk update && apk add --no-cache \
+    openjdk11-jre \
+    libgcc \
+    gcompat
+
+# Your application setup
+COPY your-app.jar /app/
+WORKDIR /app
+
+CMD ["java", "-jar", "your-app.jar"]
+```
+
+:::tip Automatic musl Detection
+The Statsig Java Core SDK automatically detects musl-based systems and will use the appropriate musl-compatible native libraries (e.g., `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`). See the [Supported OS and Architecture Combinations](#supported-os-and-architecture-combinations) section for the complete list of musl targets.
+:::
+
+:::note Package Requirements
+- `libgcc`: Provides GCC runtime library compatibility
+- `gcompat`: Provides GNU libc compatibility layer for musl systems
+:::
+
 <details>
 <summary>Method 2: Manual Configuration</summary>
 


### PR DESCRIPTION
## Description

Added documentation for Alpine Docker requirements to the Java Core SDK installation guide. This addresses the need to specify that Alpine/musl-based Docker containers require additional packages (`libgcc gcompat`) for the native libraries to work properly.

**Key Changes:**
- Added "Docker Considerations" section with Alpine Linux / musl-based container requirements
- Documented specific `apk add --no-cache libgcc gcompat` command
- Included complete example Dockerfile showing proper setup
- Added explanatory notes about package purposes (GCC runtime compatibility and GNU libc compatibility layer)
- Referenced automatic musl detection capability for troubleshooting context

![Screenshot of new Docker Considerations section](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org_NcsKoZ6bXUL52UGA/756fc3b4-34c4-46f6-baf2-e9e7ce8febe1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT7555CHVQK%2F20250811%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250811T191932Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjELz%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJGMEQCIDkTcSpwTXcVaXa7jbXnkIofZ%2BdDrDSmtAAF4EK7HlGWAiAspdrYOyV0vk4A%2F%2B%2F%2FxIj7bZeFOnkUzRZMgBnrWX%2BMKSrABQj0%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAEaDDI3MjUwNjQ5ODMwMyIMRfzaWip03utwJ0b1KpQF6O28euz%2BvlMrVtTiy9B%2BZp%2FAZlIqdXBma%2F5x8cKZDSwwt%2B20saShwjStBZ7QB7N7iPlJd%2B6CPI%2Fk8%2Fynbpqh4NHOakIGEr%2BrBL6ayi6EtiiZXBjPNC0QmOorc19fKH5Iv0x6qQWnGJjrH3PdN5RfDcBwppJxZm46PBuBeUPL38k7RLdYDtzG13L2aQ7GG6Enr0uINXXPdozqhgKzaZV174HTYYkj%2F7hRIID7K2lIi3vXWy1qSzRc1Sa0zrEsW3a1LJ41tBjk1rqsUjzZUFpNYRxCVLQ6wf27AEgH053uxRAOoCCCLBwjq86Nnti0LXwRo0EXgUxzmm3gKxp3sSShS8iVE68JtEJuVRh7j%2FIHSyJj2JDbx6fQlqKK4Csocd7eYrQ6u8TYrHhe9mK0gnuMo36%2Bry%2F8s5AgQQIOZpjFj2JdH4ANqVYuwaLBYBbbU0ErBDsoXnGMXYwFRNmN4PXJmb7JDOFjnMPsDOKA7mUNwwsGL%2FKK5E2eZHbmyx3IXchs9mLnVkfAlmidp27VvTK5RutTHLsrITJFaGQP5580bsYaQRVAP6mi8G%2FfzSH2%2BBF%2FXyj0v518zcQrADv1uMneoMduAKKhIOs1cIY95S%2FBHME56O5fCSmwfZGUb9gon6%2BNntQO57AG7NgMhRW3ftrxve%2BdB5QZAF9gl79FRms9DDqBRCSRta8Ku9t%2BVdfehpEkKokae7HFM%2FWzenWYspHrrmexNPVJ1qdiv%2FNBWfkxYC%2BY0k1KJs2u9xa0in4Cjd73UlxFC3PPTOd6NEO1XgyqL4vI1DdTx76s%2Bo6iCp%2FVA7tHnCcNNYiGR6%2FlkpP7MRECIJyigbkh8Twhwz8tSsBPnJ0dhpMEbhoT%2F5JKtHm9KhYbXijkMLaB6cQGOpkBMNTKtfiz%2BpNxWy7E%2B7JL0dFOlHyjOsH%2ByqWeNvUg%2FgNnLz%2FXGMVfwyDPMsfk%2FjY9gdjdnFkeXv%2FSSA150N0Tr2Ex3LUuISPKNbRmnqltbafJiuFcDizNnq3pgYKQMhAWzGvA1aTGRAdqBiAeP2dRzc2kOYEhojBdhCaXQ8QLGoDAQE2LiJlndjctDWNqNKttLY%2FjRtUj90ln&X-Amz-Signature=f1466e69cd6e5a6d690ba38e94561a3eec0b454302806318640675131ae31cf7)

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any  
- [x] I've updated screenshots affected by this change, if any

## Human Review Checklist

- [ ] **Verify Alpine package accuracy**: Confirm that `libgcc gcompat` are the correct and sufficient packages for Alpine/musl containers
- [ ] **Test example Dockerfile**: Validate that the provided Dockerfile example actually works with Statsig Java Core
- [ ] **Check documentation placement**: Ensure the "Docker Considerations" section is in the most logical location within the installation guide
- [ ] **Verify formatting consistency**: Confirm the new section matches existing documentation style and formatting standards
- [ ] **Validate technical claims**: Ensure references to automatic musl detection and supported musl targets are accurate

## Technical Context

This change was based on analysis of the verification container (`Dockerfile.java_amazoncorretto_21_alpine_jdk`) in the private-statsig-server-core repository, which explicitly shows `RUN apk add --no-cache libgcc gcompat`. The Java Core SDK includes musl detection logic and supports musl targets like `x86_64-unknown-linux-musl`.

---

**Link to Devin run**: https://app.devin.ai/sessions/c6a22dde076d41538767ee3479174db9  
**Requested by**: @weihao-statsig