### PR TITLE
Update slack links

### DIFF
--- a/docs/integrations/pulumi.md
+++ b/docs/integrations/pulumi.md
@@ -103,4 +103,4 @@ Coming Soon:
 - Dynamic Configs
 - Segments
 
-If you need more from our Pulumi Provider, please feel free to ask in [Slack support](https://statsigcommunity.slack.com/archives/C01RAKM10TD). This will help us prioritize what to work on.
+If you need more from our Pulumi Provider, please feel free to ask in the [Statsig Slack channel](https://statsig.com/slack).

--- a/docs/integrations/terraform/introduction.md
+++ b/docs/integrations/terraform/introduction.md
@@ -22,4 +22,4 @@ Coming Soon:
 - Dynamic Configs
 - Segments
 
-If you need more from our Terraform Provider, please feel free to ask in [Slack support](https://statsigcommunity.slack.com/archives/C01RAKM10TD). This will help us prioritize what to work on.
+If you need more from our Terraform Provider, please feel free to ask in the [Statsig Slack channel](https://statsig.com/slack).


### PR DESCRIPTION
## Description

Slack links should use Statsig.com/slack

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!