### PR TITLE
Moved Logs Explorer to it's own section and referencing alerts + MEx

### DIFF
--- a/docs/infra-analytics/logs-explorer.mdx
+++ b/docs/infra-analytics/logs-explorer.mdx
@@ -1,0 +1,41 @@
+---
+title: Logs Explorer
+tags:
+- Statsig Cloud 
+sidebar_label: Logs Explorer
+slug: /infra-analytics/logs-explorer
+keywords:
+  - owner:laurel
+last_update:
+  date: 2025-08-26
+---
+import GitHubEmbed from "@site/src/components/GitHubEmbed";
+
+
+---
+## Logs Explorer  
+
+Logs Explorer provides a way for you to search and analyze all of your product’s logs in one place. It is designed to help you quickly find the signals you care about, whether you’re debugging an incident, tracking regressions, or exploring system behavior.  
+
+---
+
+### Searching in Logs Explorer  
+To identify the entries that matter, you can either search directly through a custom query or use our point-and-click query constructor. 
+
+Once you’ve found something of interest, you can filter and group by metadata fields (such as service, host, or status code) to uncover patterns and trends.  
+- **Filtering**: Narrow down logs to the subset relevant to your investigation.  
+- **Grouping**: Aggregate logs across dimensions (service, region, status, browser, etc.).  
+- **Visualization**: Plot log groupings over time to detect spikes, regressions, or unusual changes.  
+
+### Visualizations in Logs Explorer  
+In Log Explorer, visualizations make it easy to move beyond raw text logs into structured insights. For example, you can group logs by browser name and track how distributions change over time. These visualizations let you spot anomalies and shifts at a glance.  
+
+---
+
+### Getting Started with Log Explorer  
+To get started with Log Explorer, follow the [OTEL onboarding guide](/server/concepts/open_telemetry) to set up log ingestion. Once that's ready, you can navigate to **Infra Analytics → Log Explorer** in the Statsig sidebar to begin exploring your logs. 
+
+---
+:::info
+Interested in Traces? Reach out in Slack to get access.
+::: 

--- a/docs/infra-analytics/overview.mdx
+++ b/docs/infra-analytics/overview.mdx
@@ -13,30 +13,38 @@ import GitHubEmbed from "@site/src/components/GitHubEmbed";
 
 # Infra Analytics Overview
 
-**[Infra Analytics](https://statsig.com/infra-analytics)** helps you understand and protect the health of your system through logs, metrics, and traces. It provides a unified interface to explore, query, and alert on signals.
+**[Infra Analytics](https://statsig.com/infra-analytics)** helps you monitor and debug the health of your services with logs, metrics, and alerts inside Statsig. It brings system-level observability into the same platform where you analyze product outcomes, giving you a unified view across your stack.
 
-Logs Explorer is the primary surface of Infra Analytics.
-
----
-## Logs Explorer  
-
-Logs Explorer provides a way for you to search and analyze all of your product’s logs in one place. It is designed to help you quickly find the signals you care about, whether you’re debugging an incident, tracking regressions, or exploring system behavior.  
-
-### Searching in Logs Explorer  
-To identify the entries that matter, you can either search directly through a custom query or use our point-and-click query constructor. 
-
-Once you’ve found something of interest, you can filter and group by metadata fields (such as service, host, or status code) to uncover patterns and trends.  
-- **Filtering**: Narrow down logs to the subset relevant to your investigation.  
-- **Grouping**: Aggregate logs across dimensions (service, region, status, browser, etc.).  
-- **Visualization**: Plot log groupings over time to detect spikes, regressions, or unusual changes.  
-
-### Visualizations in Logs Explorer  
-In Log Explorer, visualizations make it easy to move beyond raw text logs into structured insights. For example, you can group logs by browser name and track how distributions change over time. These visualizations let you spot anomalies and shifts at a glance.  
-
-### Getting Started with Log Explorer  
-To get started with Log Explorer, follow the [OTEL onboarding guide](/server/concepts/open_telemetry) to set up log ingestion, then navigate to **Infra Analytics → Log Explorer** in the Statsig sidebar to begin exploring your logs. 
+With Infra Analytics, you can:  
+- Search and analyze logs to investigate issues  
+- Collect metrics and traces through OpenTelemetry (OTEL)  
+- Create alerts tied to service health  
+- Connect infrastructure signals to product analytics for a unified understanding of impact  
 
 ---
+
+## Feature Highlights  
+
+- **[Logs Explorer](/infra-analytics/logs-explorer)**: Search, filter, group, and visualize logs to debug incidents and analyze patterns 
+- **[Topline Alerts](/product-analytics/alerts/topline_alerts)**: Detect regressions and anomalies with log or metric based alerts
+- **[Metrics Explorer](/product-analytics/drilldown)**: Analyze infrastructure metrics in the same place you analyze product metrics
+
+---
+
+## Start Sending Data  
+
+To start using Logs Explorer, you need to **[set up your OTEL ingestion](/server/concepts/open_telemetry)**.  
+
 :::info
 Interested in Traces? Reach out in Slack to get access.
-:::
+::: 
+---
+
+## Related Links
+
+Infra Analytics builds on existing Statsig capabilities. You may also find these docs interesting:  
+
+- [Create a Topline Alert](/product-analytics/alerts/topline_alerts)  
+- [Create a Rollout Alert](/product-analytics/alerts/rollout_alerts)
+- [Set up Slack Notifications](/integrations/slack)  
+- [Create a Dashboard](/product-analytics/dashboards)  

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -427,8 +427,25 @@ const sidebars: SidebarsConfig = {
           label: "Infra Analytics",
           className: "infra-analytics-icon sidebar-icon",
           items: [
-            "infra-analytics/overview"
-          ]
+            "infra-analytics/overview",
+            "infra-analytics/logs-explorer",
+            {
+              type: "link",
+              href: "/product-analytics/alerts/topline_alerts",
+              label: "Topline Alerts"
+            },
+            {
+              type: "link",
+              href: "/product-analytics/drilldown",
+              label: "Metrics Explorer"
+            }
+          ],
+          
+        },
+        {
+          type: "doc",
+          id: "integrations/mcp",
+          className: "ai-icon sidebar-icon",
         },
         {
           type: "category",


### PR DESCRIPTION
## Description

Updated the Infra Analytics Overview content, created a new page for Log Explorer, and sidebar items that reference PA Topline Alerts + PA Metrics Explorer.
 
## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!