### PR TITLE
Fix on Athena WHN resource permissions setup page

### DIFF
--- a/docs/statsig-warehouse-native/connecting-your-warehouse/athena.md
+++ b/docs/statsig-warehouse-native/connecting-your-warehouse/athena.md
@@ -111,7 +111,7 @@ You need to grant some permissions for Statsig from your AWS console in order fo
             "Resource": [
                "arn:aws:s3:::__S3_BUCKET__/__PATH_TO_S3_QUERY_RESULTS_FOLDER__/*",
                "arn:aws:s3:::__S3_BUCKET__/__STATSIG_S3_FOLDER__/*",
-               "arn:aws:athena:__REGION__:__YOUR_AWS_ACCOUNT_ID__:workgroup/*",
+               "arn:aws:athena:__REGION__:__YOUR_AWS_ACCOUNT_ID__:workgroup/WORKGROUP_NAME",
                "arn:aws:glue:__REGION__:__YOUR_AWS_ACCOUNT_ID__:catalog",
                "arn:aws:glue:__REGION__:__YOUR_AWS_ACCOUNT_ID__:database/__GLUE_STAGING_DATABASE__",
                "arn:aws:glue:__REGION__:__YOUR_AWS_ACCOUNT_ID__:table/__GLUE_STAGING_DATABASE__/*"

--- a/docs/statsig-warehouse-native/connecting-your-warehouse/athena.md
+++ b/docs/statsig-warehouse-native/connecting-your-warehouse/athena.md
@@ -111,7 +111,7 @@ You need to grant some permissions for Statsig from your AWS console in order fo
             "Resource": [
                "arn:aws:s3:::__S3_BUCKET__/__PATH_TO_S3_QUERY_RESULTS_FOLDER__/*",
                "arn:aws:s3:::__S3_BUCKET__/__STATSIG_S3_FOLDER__/*",
-               "arn:aws:athena:__REGION__:__YOUR_AWS_ACCOUNT_ID__:workgroup/WORKGROUP_NAME",
+               "arn:aws:athena:__REGION__:__YOUR_AWS_ACCOUNT_ID__:workgroup/__WORKGROUP_NAME__",
                "arn:aws:glue:__REGION__:__YOUR_AWS_ACCOUNT_ID__:catalog",
                "arn:aws:glue:__REGION__:__YOUR_AWS_ACCOUNT_ID__:database/__GLUE_STAGING_DATABASE__",
                "arn:aws:glue:__REGION__:__YOUR_AWS_ACCOUNT_ID__:table/__GLUE_STAGING_DATABASE__/*"


### PR DESCRIPTION
## Description

Brief summary or screenshot of your changes

Fixing an error identified in POC when setting up athena. Resource should be
"arn:aws:athena:__REGION__:__YOUR_AWS_ACCOUNT_ID__:workgroup/__WORKGROUP_NAME__",
rather than referencing all workspaces with "/*"

<img width="862" height="198" alt="image" src="https://github.com/user-attachments/assets/51471381-d008-4a96-8deb-a8df7801aa88" />

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!