### PR TITLE
Remove beta tag from .NET Core Server SDK documentation

### DIFF
--- a/docs/server-core/dotnetCoreSDK.mdx
+++ b/docs/server-core/dotnetCoreSDK.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_label: .NET (Beta)
-title: .NET Core Server SDK (Beta)
+sidebar_label: .NET
+title: .NET Core Server SDK
 keywords:
   - owner:brock
 last_update:


### PR DESCRIPTION
## Description

Removed "(Beta)" designation from the .NET Core Server SDK documentation as requested by @weihao-statsig. 

**Changes:**
- Updated sidebar label from ".NET (Beta)" to ".NET" 
- Updated page title from ".NET Core Server SDK (Beta)" to ".NET Core Server SDK"

![Local testing verification](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org_NcsKoZ6bXUL52UGA/1bb0bc3a-0a52-46ed-a1b7-08fc1b07bde4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT7RBOMAZAR%2F20250905%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250905T220250Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEBYaCXVzLWVhc3QtMSJHMEUCIQClSXlRFAQf358uKD8g8ApqU0%2BNzuxSYUCK4TwWFzI7EgIgKYey82Ys4YRY%2BTDkLLaC3wUuApTrmoDsbKJ4M65hlLgqtwUIfxABGgwyNzI1MDY0OTgzMDMiDFgunv%2FEF02gEx29RSqUBSnWeHgVeNcFQ1%2BWyRn%2B1LDWSZ4qMeE362Fe17RuKOb%2Bf1UJZnMj2%2FI2nMEVr6A2aB5LYb%2Ba%2F9U5N0hmvqKB1te%2FJOpczF%2F%2Fk4EtqmHi45kwDtA8A18FUC%2F7hWC1tsMR5kgSw2zOXSihVNMydaWazZ3G7Q5f1EjRokTt2qdocrjGke%2FEn9HIomUHFRn0E%2FOFXQ9hSec8zuDvdYyQAfuYUhNelbHLgLbdE8zc00bJKFyXVR3YTc2nCiemhWR9lkt4LJmvVoX6aX7UN%2FXrf5%2Bp8PGO4XrUOZwhggZYqzBDe13RjCz0pKiWqFov6oU2JisvLT%2Frsa6%2FdvlrWZrZbJdPoxKRqb1FZAL%2B0w71%2Fwo69yIiN5WuJNONE0inlL1S9X4aLhzRsiUlwWYHAIqflsCCMPGOSYbscZ%2BXh%2BXRllYRhh3WWZhTuA17OJQw1C2UlgHYgLHGx4xIcLJDPt2BChlqeGCs6FOkfcrsSNkWUb7xRBGKkDWZoqa7Q83AUcRHQhqPotOom0JA2zZWxZC%2FND4%2BPQqEnATnI0kL2LM058vuQ%2BJCxSlyQRyUUsm34cD0TeK%2F3vw%2FPXHDyA6NovLFwwHhNASHt3ejsM6KHYMQMaWfBf%2FpyeGv29n%2BKuR7VftKCpPNfPGQJ2M1kFYkHCKSBdRYBCl75uDfEi8Cb6KM8LILLHHXfNWP7gqhbcDOUqG%2FlXdAtWb52MZ7C9UfBTrgP9zX3cPPwofwni7lPXM5h11AQ6jG0%2B%2BSldubbm3MPuXD40EP4fsusvwXRB%2FwfuOJJSweHPak5pEeR5a4k6mHTjErec1dDKl6SJjtgsNB%2BwS18XVFW%2B%2BZglBy5UTVYFrvf5jiiU2dlMaE7Ty05ObampN0jwkpNygdQzDSuO3FBjqYARCy%2FbkQrZYlLzaSi4CRcS4K4WNhJxvdd4sS7bhCTO8vM9P98P0U8qPpa7x%2B6K82djlpj98Wss45H0uVcZDsz%2B0HoF81VDkN1N3VRTNYiZ%2FMskS%2BkoPOjzuFrOkTDIFBnv%2Fy%2BgME0CRPBYiE%2B0lS1MT5JYaB%2BgaiWpvMA8XLRb5NPG%2B5gxMey7DbhnUV67l6E52JvP%2FQsg0t&X-Amz-Signature=6fdb738e716f8b599d19c1411b3e9e5a1fb4b6a9f0470c77b99d46cd0d3654a3)

The changes were tested locally and render correctly - the sidebar now shows ".NET" and the page displays ".NET Core Server SDK" without beta designation.

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any (N/A - no page deletions)
- [x] I've updated links affected by this change, if any (N/A - no link changes needed)
- [x] I've updated screenshots affected by this change, if any (N/A - content screenshots unchanged)

## Human Review Checklist

- [ ] **Verify .NET Core SDK is ready for beta removal** - Confirm with engineering that the .NET Core SDK is stable enough to remove beta designation
- [ ] **Check for any missed beta references** - Verify no other .NET documentation contains beta tags that should also be removed
- [ ] **Visual verification** - Confirm the sidebar and page title display correctly without "(Beta)"

## Questions?

Reach out to Brock or Tore on Slack!

---

**Link to Devin run:** https://app.devin.ai/sessions/effcb6ec3e7d496baf213519894e0da0  
**Requested by:** @weihao-statsig