### PR TITLE
Replace docs_signup_cta experiment with docs_cta dynamic config

### DIFF
--- a/src/components/NavbarItems/SignupCTA/index.js
+++ b/src/components/NavbarItems/SignupCTA/index.js
@@ -1,13 +1,13 @@
 import React from "react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
-import { useExperiment } from "../../lib/statsig";
+import { useDynamicConfig } from "../../lib/statsig";
 
 const SignupCTA = () => (
   <BrowserOnly>
     {() => {
-      const ctaExp = useExperiment("docs_signup_cta");
-      const url = ctaExp?.get("url") ?? "https://console.statsig.com";
-      const cta = ctaExp?.get("cta") ?? "Get Started";
+      const ctaConfig = useDynamicConfig("docs_cta");
+      const url = "https://console.statsig.com";
+      const cta = ctaConfig?.get("cta") ?? "Get Started";
       return (
         <a className="navbar__item" href={url} target="_blank">
           <button className="signupCTA CTA">{cta}</button>

--- a/src/components/lib/statsig.js
+++ b/src/components/lib/statsig.js
@@ -25,3 +25,21 @@ export function useExperiment(name) {
   }, [name, statsig]);
   return exp;
 }
+
+export function useDynamicConfig(name) {
+  const statsig = getStatsig();
+  const [config, setConfig] = useState(
+    statsig.loadingState === "Ready" ? statsig.getDynamicConfig(name) : null
+  );
+  useEffect(() => {
+    function handler() {
+      setConfig(statsig.getDynamicConfig(name));
+    }
+
+    statsig.on("values_updated", handler);
+    return () => {
+      statsig.off("values_updated", handler);
+    };
+  }, [name, statsig]);
+  return config;
+}


### PR DESCRIPTION
- Add useDynamicConfig hook to statsig.js
- Update SignupCTA component to use dynamic config instead of experiment
- Hardcode URL to console.statsig.com while keeping CTA text configurable
- Remove dependency on A/B testing for CTA button

## Description

Brief summary or screenshot of your changes

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!