### PR TITLE
docs: add missing wait_for_*_init options to PHP core SDK

### DIFF
--- a/docs/server-core/dotnet-core/_options.mdx
+++ b/docs/server-core/dotnet-core/_options.mdx
@@ -12,6 +12,8 @@ var options = new StatsigOptionsBuilder()
     .SetDisableCountryLookup(false)
     .SetDisableUserAgentParsing(false)
     .SetDisableAllLogging(false)
+    .SetInitTimeoutMs(3000)
+    .SetFallbackToStatsigApi(false)
     .SetEnableIDLists(true)
     .SetIDListsURL("https://custom-api.statsig.com/v1/get_id_lists")
     .SetIDListsSyncIntervalMs(60000)
@@ -37,6 +39,8 @@ var statsig = new Statsig("server-secret-key", options);
 - **SetDisableCountryLookup(bool)**: Disable automatic country detection
 - **SetDisableUserAgentParsing(bool)**: Disable user agent parsing
 - **SetDisableAllLogging(bool)**: Disable all event logging
+- **SetInitTimeoutMs(int)**: Maximum time in milliseconds to wait for SDK initialization (default: 3000ms)
+- **SetFallbackToStatsigApi(bool)**: Fallback to Statsig API when custom adapters fail (default: false)
 - **SetEnableIDLists(bool)**: Enable ID list targeting
 - **SetIDListsURL(string)**: Override the default ID lists endpoint
 - **SetIDListsSyncIntervalMs(int)**: How often to sync ID lists (default: 60000ms)

--- a/docs/server-core/go/_options.mdx
+++ b/docs/server-core/go/_options.mdx
@@ -46,6 +46,15 @@ The `StatsigOptions` class is used to specify optional parameters when initializ
 
   When set to true, the SDK will not log any events or exposures.
 
+- **`InitTimeoutMs`**: 
+  Default: 3000
+
+  Maximum time in milliseconds to wait for SDK initialization to complete. If initialization takes longer than this timeout, the SDK will continue to operate but may return default values until initialization completes.
+
+- **`FallbackToStatsigApi`**: 
+  Default: false
+
+  When set to true, the SDK will fallback to using the Statsig API directly if custom adapters (like local file adapters) fail to load configurations.
 
 ---
 
@@ -68,6 +77,8 @@ options := statsig.NewStatsigOptionsBuilder().
 		WithDisableCountryLookup(true).
 		WithDisableUserAgentParsing(true).
 		WithWaitForCountryLookupInit(false).
+		WithInitTimeoutMs(3000).
+		WithFallbackToStatsigApi(false).
 		Build()
 
 // Pass the options object when initializing the Statsig client

--- a/docs/server-core/php/_options.mdx
+++ b/docs/server-core/php/_options.mdx
@@ -41,6 +41,16 @@ The `StatsigOptions` class is used to specify optional parameters when initializ
 - **`disable_user_agent_parsing`**: 
   Disables user agent parsing. Set to `true` to improve performance if device/browser-based targeting is not needed.
 
+- **`wait_for_country_lookup_init`**: 
+  Default: false
+  
+  When set to true, the SDK will wait for country lookup data (e.g., GeoIP or YAML files) to fully load during initialization. This may slow down by ~1 second startup but ensures that IP-to-country parsing is ready at evaluation time.
+
+- **`wait_for_user_agent_init`**: 
+  Default: false
+  
+  When set to true, the SDK will wait until user agent parsing data is fully loaded during initialization. This may slow down by ~1 second startup but ensures that parsing of the user's userAgent string into fields like browserName, browserVersion, systemName, systemVersion, and appVersion is ready before any evaluations.
+
 - **`enable_id_lists`**: 
   Enable/disable ID list functionality. **Required to be `true` when using segments with more than 1000 IDs.** See [ID List segments](/segments/add-id-list) for more details.
 
@@ -77,7 +87,9 @@ $options = new StatsigOptions(
     600000, // specs_sync_interval_ms
     "INFO", // output_log_level
     true, // disable_country_lookup (for better performance)
-    true  // disable_user_agent_parsing (for better performance)
+    true, // disable_user_agent_parsing (for better performance)
+    false, // wait_for_country_lookup_init
+    false  // wait_for_user_agent_init
 );
 
 // Pass the options object into Statsig constructor

--- a/docs/server-core/php/_options.mdx
+++ b/docs/server-core/php/_options.mdx
@@ -41,15 +41,15 @@ The `StatsigOptions` class is used to specify optional parameters when initializ
 - **`disable_user_agent_parsing`**: 
   Disables user agent parsing. Set to `true` to improve performance if device/browser-based targeting is not needed.
 
-- **`wait_for_country_lookup_init`**: 
-  Default: false
+- **`init_timeout_ms`**: 
+  Default: 3000
   
-  When set to true, the SDK will wait for country lookup data (e.g., GeoIP or YAML files) to fully load during initialization. This may slow down by ~1 second startup but ensures that IP-to-country parsing is ready at evaluation time.
+  Maximum time in milliseconds to wait for SDK initialization to complete. If initialization takes longer than this timeout, the SDK will continue to operate but may return default values until initialization completes.
 
-- **`wait_for_user_agent_init`**: 
+- **`fallback_to_statsig_api`**: 
   Default: false
   
-  When set to true, the SDK will wait until user agent parsing data is fully loaded during initialization. This may slow down by ~1 second startup but ensures that parsing of the user's userAgent string into fields like browserName, browserVersion, systemName, systemVersion, and appVersion is ready before any evaluations.
+  When set to true, the SDK will fallback to using the Statsig API directly if custom adapters (like local file adapters) fail to load configurations.
 
 - **`enable_id_lists`**: 
   Enable/disable ID list functionality. **Required to be `true` when using segments with more than 1000 IDs.** See [ID List segments](/segments/add-id-list) for more details.
@@ -89,7 +89,11 @@ $options = new StatsigOptions(
     true, // disable_country_lookup (for better performance)
     true, // disable_user_agent_parsing (for better performance)
     false, // wait_for_country_lookup_init
-    false  // wait_for_user_agent_init
+    false, // wait_for_user_agent_init
+    false, // disable_network
+    false, // disable_all_logging
+    3000, // init_timeout_ms
+    false  // fallback_to_statsig_api
 );
 
 // Pass the options object into Statsig constructor


### PR DESCRIPTION
## Description

Updates server-core SDK documentation for .NET, Go, and PHP to include two new StatsigOptions added in [PR #1885](https://github.com/statsig-io/private-statsig-server-core/pull/1885):

- **`init_timeout_ms` / `InitTimeoutMs` / `SetInitTimeoutMs`**: Maximum time in milliseconds to wait for SDK initialization (default: 3000ms)
- **`fallback_to_statsig_api` / `FallbackToStatsigApi` / `SetFallbackToStatsigApi`**: Whether to fallback to Statsig API when custom adapters fail (default: false)

All three SDK documentation pages now include these options in both their parameter lists and constructor/builder examples.

![PHP Core Documentation](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org_NcsKoZ6bXUL52UGA/e84788e0-a334-443a-806e-a348b9e03aaa?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT7ZVMGW2AK%2F20250915%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250915T215404Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEAYaCXVzLWVhc3QtMSJIMEYCIQDDxq9IvGgPCiJ8r1Cl0WGNQQcpM7CHXAQB2xQ9Eb424wIhAMnp81DDXfT%2FJqlXoYZOkKrK%2Fmok7oYbchSRbmcvpQeLKrcFCH8QARoMMjcyNTA2NDk4MzAzIgxPofQhi7vPZyZK4ggqlAVKShJTllrSnPF43%2B7Bgg6dOLumZzulKuXd7GB%2FIpOPMCnP4RH0%2FI0qUMb5YBMlfyyirTqH2UxcMSUHSHKp7g0vNzGyUpJMySRzL%2FBh74LNLFlPz%2FY3%2F%2BAHtDZD99jqopI56MGoMFuZCq6Fv9v4CYqPW2wCtTink8iNlrIRXoBpSRm89q2hUuMVv6TKzxr5SR0MOhQ3mT2nJvpxKSRvmhWZYcruPDvNr1aGRqYN6ygPFW9DVvmIae1iYFVOjbcE6Sh21F3pdmvO7aewpLQuqVvB%2BYw%2FAZhXR4ObN6IYLTqYrW6dn%2BSp4k9KaIWZY7Uv4Z5s%2F8N8ehy0kaxte8j%2FCq2pM7%2Bv6QBLeBDQWz906i2izk8YmGL65fW6RNkmYMjksOUszDfg2kFpdNxX1K1UXpVzBDvf9z81W%2BwVce0yh6e4I6v4mWblpsgvXKJiE8FPS995v9%2Ft69x96csGYtcWsbFCJUfy%2B0i%2BgKKSHXh1YN8Zq52zQxwzwzMqeECL%2FR%2FqL9n2WbEzdKLNyRlced2RHsvmr7C9uCgGUObZwmb5q9UToC7wmnG%2F4sFiSTMy3fSw7zv3NEHURSsBQJEuQpHrP9S3DkNbBRvqLdA5uZEpOUyZIurrWZmR0Ac44Mm5xD2XHMwI9d0M43cdwYd2n6GnqwlXaAymw852jjcGdXuq0iedS5Li%2Fp4vosfSjJH5NQ8x3xGPt9Plg%2Bp8kcSDdLVEvgWYWPdfcpCaRqSEBNlxLYqvGFSjodvv9dbyikoDPon1ytEkd7cYrQZQOIZWl1TlENMitw7EluAICelfZrxtc%2BnuO9Xye8VBOZEuW6kzpfny3s%2BgLZp7t5yIQeKUaub2T3P5h4yiZK1hP5BU8iM%2FrWWXOwd7ebsw%2BpOixgY6lwG9sNlcOgA3glJNlamX2HG6l9lmoTMgivfJIAT940SyQFJuTN5agzH13iO%2B6n0Syk0yy0tD8TD%2BXzfyuQ4425vDu2EJjxz5gashCePUJvYOzWK85Ng4EH0dZO0VXB%2F1Hby3MjaH5xs83xLHCmFLx2MGOWl1vC1QqGgsuKaCPBh61BFitPdAHzrLIImlZ7yE0QjVxXv%2FPrli&X-Amz-Signature=64242fed399b570060584ddf21a624cf396120673732160169a43930fc132041)

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Human Review Checklist

**⚠️ Critical Items to Verify:**
- [ ] **Parameter order in PHP constructor example** - Verify the parameter order and count matches the actual `StatsigOptions` constructor signature in PHP
- [ ] **Default values across SDKs** - Confirm that 3000ms and false are the correct default values for all three SDK implementations  
- [ ] **Method/parameter naming consistency** - Verify that `SetInitTimeoutMs`/`WithInitTimeoutMs`/`init_timeout_ms` naming matches actual SDK implementations
- [ ] **Description accuracy** - Confirm that the behavioral descriptions match how these options actually work in the SDKs

**Context**: This PR initially documented incorrect options and had to be corrected, so extra verification against actual SDK implementations is recommended.

**Link to Devin session**: https://app.devin.ai/sessions/d2bc151b5a8d443a8a4b6f8e9360126f  
**Requested by**: @weihao-statsig

## Questions?

Reach out to Brock or Tore on Slack!