### PR TITLE
change example in logs explorer queries example

### DIFF
--- a/docs/infra-analytics/logs-explorer-queries.mdx
+++ b/docs/infra-analytics/logs-explorer-queries.mdx
@@ -63,5 +63,5 @@ You can use the `*` character as a wildcard in queries. A wildcard matches zero 
 | `@"log.file.path":"/logs/pods/*"`    | Path begins with `/logs/pods/`                     | `/logs/pods/1234/stdout.log`              |
 | `@"log.file.path":"*/logs/pods/"`    | Path ends with `/logs/pods/`                       | `/mnt/storage/logs/pods/`                 |
 | `service:"api-*"`                      | Services with names starting with `api-`           | `api-gateway`, `api-auth`                 |
-| `route:"*products/*"`                  | Page routes containing the string `products/`         | `shopify.com/products/tshirts`, `shopify.com/cart/products/view`  |
+| `@route:"*products/*"`                  | Page routes containing the string `products/`         | `shopify.com/products/tshirts`, `shopify.com/cart/products/view`  |
 | `@message!:""`                        | Return logs where the message field is **not null**| any log that has a `message` field        |

--- a/docs/infra-analytics/logs-explorer-queries.mdx
+++ b/docs/infra-analytics/logs-explorer-queries.mdx
@@ -63,5 +63,5 @@ You can use the `*` character as a wildcard in queries. A wildcard matches zero 
 | `@"log.file.path":"/logs/pods/*"`    | Path begins with `/logs/pods/`                     | `/logs/pods/1234/stdout.log`              |
 | `@"log.file.path":"*/logs/pods/"`    | Path ends with `/logs/pods/`                       | `/mnt/storage/logs/pods/`                 |
 | `service:"api-*"`                      | Services with names starting with `api-`           | `api-gateway`, `api-auth`                 |
-| `message:"*timeout*"`                  | Log messages containing the word `timeout`         | `connection timeout`, `timeout exceeded`  |
+| `route:"*products/*"`                  | Page routes containing the string `products/`         | `shopify.com/products/tshirts`, `shopify.com/cart/products/view`  |
 | `@message!:""`                        | Return logs where the message field is **not null**| any log that has a `message` field        |


### PR DESCRIPTION
re: brent's feedback about the @message: example

## Description

Re: Brent's feedback around the` @message:` wildcard example. Updated it to be an example on `route`.

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!