### PR TITLE
Add FastAPI integration example to Python Core SDK initialization docs

### DIFF
--- a/docs/server-core/python/_initialize.mdx
+++ b/docs/server-core/python/_initialize.mdx
@@ -1,3 +1,6 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 ```python
 from statsig_python_core import Statsig, StatsigOptions # note, import statement has underscores while install has dashes
 
@@ -25,6 +28,16 @@ The Python Core SDK uses internal threading and async runtime components that do
 ### Initializing with WSGI servers
 
 For production deployments using WSGI servers like uWSGI or Gunicorn, ensure Statsig is initialized **after** the worker processes are forked, not in the main process.
+
+<Tabs
+  groupId="python-server-deployment"
+  defaultValue="uwsgi"
+  values={[
+    {label: 'uWSGI', value: 'uwsgi'},
+    {label: 'Gunicorn', value: 'gunicorn'},
+    {label: 'FastAPI', value: 'fastapi'},
+  ]}>
+  <TabItem value="uwsgi">
 
 #### ✅ Correct: uWSGI example
 
@@ -64,6 +77,9 @@ processes = 4
 # Statsig will be initialized in each worker process
 ```
 
+  </TabItem>
+  <TabItem value="gunicorn">
+
 #### ✅ Correct: Gunicorn example
 
 ```python
@@ -80,3 +96,37 @@ def post_fork(server, worker):
 # Start Gunicorn with post-fork hook
 gunicorn --config gunicorn_config.py app:app
 ```
+
+  </TabItem>
+  <TabItem value="fastapi">
+
+#### ✅ Correct: FastAPI example
+
+```python
+from fastapi import FastAPI
+from statsig_python_core import Statsig, StatsigOptions
+
+app = FastAPI()
+statsig = None
+
+@app.on_event("startup")
+async def startup_event():
+    global statsig
+    options = StatsigOptions()
+    options.environment = "production"
+    statsig = Statsig("your-server-secret-key", options)
+    statsig.initialize().wait()
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    if statsig:
+        statsig.shutdown().wait()
+
+@app.get("/")
+async def root():
+    # Use statsig here
+    return {"message": "Hello World"}
+```
+
+  </TabItem>
+</Tabs>

--- a/docs/server-core/python/_initialize.mdx
+++ b/docs/server-core/python/_initialize.mdx
@@ -31,13 +31,13 @@ For production deployments using WSGI servers like uWSGI or Gunicorn, ensure Sta
 
 <Tabs
   groupId="python-server-deployment"
-  defaultValue="uwsgi"
+  defaultValue="uWSGI"
   values={[
-    {label: 'uWSGI', value: 'uwsgi'},
+    {label: 'uWSGI', value: 'uWSGI'},
     {label: 'Gunicorn', value: 'gunicorn'},
-    {label: 'FastAPI', value: 'fastapi'},
+    {label: 'FastAPI', value: 'FastAPI'},
   ]}>
-  <TabItem value="uwsgi">
+  <TabItem value="uWSGI">
 
 #### ✅ Correct: uWSGI example
 
@@ -98,7 +98,7 @@ gunicorn --config gunicorn_config.py app:app
 ```
 
   </TabItem>
-  <TabItem value="fastapi">
+  <TabItem value="FastAPI">
 
 #### ✅ Correct: FastAPI example
 


### PR DESCRIPTION
## Description

Adds FastAPI integration guidance to the Python Core SDK initialization documentation. The change converts the existing WSGI server section from linear examples to a tabbed interface, adding FastAPI as a third option alongside uWSGI and Gunicorn.

**Screenshot of changes:**
![FastAPI tab implementation](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org_NcsKoZ6bXUL52UGA/4219f5f9-7c7f-4a4a-8266-e9962c71d655?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT76GMSJ3N6%2F20250917%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250917T234516Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEDgaCXVzLWVhc3QtMSJHMEUCIQC5vOJKxw2S2PJohMx4wk1k52DJYPSanG%2FumQFnPhhXdwIgCUUubqGQZ2%2B52%2BiLKf1mMK%2FemKqet%2Bug%2FapmENl%2FZ8sqwAUIsf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARABGgwyNzI1MDY0OTgzMDMiDDVNi7nZL4l0DLnGQyqUBVSsVyUdgf5GQQmxk2AE%2BEmDY%2Fryi6SvfJ1SDAqSB%2Bd2Kmwnq6aBwd3toCK%2B4wbH4%2FCqtUWjm64eKed5p3cUEwNvMzNwXFyp8yrQ%2BFDATdD0kflhB8HiRyBifbQUMaX1AG0S5CIcoHt8Qk3chOxAgSqoOoyVFsClbIuZFhK%2B1jZLxqgNs3cPZWbnwHYnCqKyat8A9blq3UsjXr1qCwDZYSGDvxFu5qggk6FnTddY3ZWhZDksCsnNlcEFT1i1fvM6NFDgmG99XSFlmY7%2Fpiwz9Xh0z0NkFMxxxdjOw6GvnyKkujPsl3avMfMCGNnVdbsXi4FLCRNsOswQjMBxtMxtzRAap8MGdj195j0K%2BqmPwKCLOYfTkWbqlha%2Bh8MabfgiZouCHqkgMWKChb3a%2BHoE8ykHB6kkZ7%2BYs0rXlUSEaLEOy8L6dtaircq0RRjEfYKytyKzbDcLkiZFcu%2BYHdfT8NNZC33XlDWukXihjf2uC09yC2ExP9yQXc%2BtR22uV34LDzpUaQvpzalIj%2BuItr16o%2BXSpHxBH6u1myJBIiDadYYJlBADLnX9en51fvCUoCpGfKNKKCRIxFdxuZpW5X7azuS0sbIM5SsbBXnQu3OnMAYLt7xjLqDKhMY8EyV%2Bupm9Mg%2FEO3ssL1Pknnn0ccUxsPZQMfSxe5XJB3kLE%2B73NiLzc6XkrSO5u9WbtrbTJl1Qwc35qh40yXw%2BsrtHrubFpddOt%2FOAZdur9EB52xkQyr28hTim6THRBkiCIy8RLC7FtRf8vLDy49doH6GNHxcBVR5sKKZOs5ry%2FD5lPO%2BhXGM%2FPwPBaAzroSR3SXmsN34Hp%2Bk%2B1%2Fc2pboYP%2BIl8Is94GQ1jAHBrCgLzFC%2FDT6Hw4qu8X506jCnhq3GBjqYAZv59GKNhwHCkXCOHvGDHKFoHZoSK3WRhosNw6Pii5rhNV1PfImAh5GPZhNvNnsqBEbBJ0YzOKTbTjrgFK%2F1n89uq2J9L43t3qtok4J1q3cfazaWFRmn7c2l72OVqNBnke4%2B%2FmgF9A3HMMVYTMNV559SBbIxojJmw7S56lF7nz7VGDCUcTg7iTQ1lK6KARLGYRmmVjztTN4i&X-Amz-Signature=06263947d413839a035dde80b9001e79a0d99c661062479ce2d4156db136b40f)

The FastAPI example uses:
- `@app.on_event("startup")` and `@app.on_event("shutdown")` lifecycle events
- Python Core SDK's `.wait()` pattern: `statsig.initialize().wait()` and `statsig.shutdown().wait()`
- Global variable pattern consistent with existing uWSGI example

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Key areas for review

1. **Method correctness**: Please verify that `statsig.initialize().wait()` and `statsig.shutdown().wait()` are the correct methods for Python Core SDK async integration
2. **FastAPI lifecycle pattern**: Confirm that `@app.on_event()` decorators are preferred over the newer lifespan context manager for this use case
3. **Code example quality**: Review if the global variable approach and overall FastAPI example follows current best practices

## Questions?

Reach out to Brock or Tore on Slack!

---

**Link to Devin run:** https://app.devin.ai/sessions/94812dadc6ee4ddcafdd90ff124df872  
**Requested by:** @tore-statsig