### PR TITLE
Add missing React hooks to React Native documentation

### DIFF
--- a/docs/client/ReactNative/_reference.mdx
+++ b/docs/client/ReactNative/_reference.mdx
@@ -78,6 +78,39 @@ Returns `GateResult`:
 - `isLoading: boolean;` - the loading/initializing state of the SDK
 - `value: boolean` - the value of the feature gate (false by default)
 
+### `useGateValue`
+
+A react hook to get the boolean value of a Statsig Feature Gate. This is a convenience hook that returns just the boolean value.
+
+Parameters:
+
+- `gateName: string` - the name of the gate to check
+
+Returns `boolean`:
+
+- `value: boolean` - the value of the feature gate (false by default)
+
+:::note
+This hook will log an exposure on render. Use `useStatsigClient.checkGate` if you need to control when the exposure is logged.
+:::
+
+### `useFeatureGate`
+
+A react hook to get a Statsig Feature Gate object with additional metadata.
+
+Parameters:
+
+- `gateName: string` - the name of the gate to check
+
+Returns `FeatureGate`:
+
+- `isLoading: boolean;` - the loading/initializing state of the SDK
+- `gate: FeatureGate` - the backing `FeatureGate` object with additional metadata
+
+:::note
+This hook will log an exposure on render. Use `useStatsigClient.checkGate` if you need to control when the exposure is logged.
+:::
+
 ### `useConfig`
 
 A react hook to get a Statsig Dynamic Config.
@@ -90,6 +123,23 @@ Returns `ConfigResult`:
 
 - `isLoading: boolean;` - the loading/initializing state of the SDK
 - `config: DynamicConfig` - the backing `DynamicConfig` (see the [statsig-js sdk docs](/client/deprecated/jsClientSDK) for more information)
+
+### `useDynamicConfig`
+
+A react hook to get a Statsig Dynamic Config. This is a convenience hook that returns the config and logs an exposure on render.
+
+Parameters:
+
+- `configName: string` - the name of the config to get
+
+Returns `ConfigResult`:
+
+- `isLoading: boolean;` - the loading/initializing state of the SDK
+- `config: DynamicConfig` - the backing `DynamicConfig`
+
+:::note
+This hook will log an exposure on render. Use `useStatsigClient.getDynamicConfig` if you need to control when the exposure is logged.
+:::
 
 ### `useExperiment`
 
@@ -116,6 +166,107 @@ Returns `LayerResult`:
 
 - `isLoading: boolean;` - the loading/initializing state of the SDK
 - `layer: Layer` - the backing `Layer` (see the [statsig-js sdk docs](/client/deprecated/jsClientSDK) for more information)
+
+### `useParameterStore`
+
+A react hook to get a Statsig Parameter Store.
+
+Parameters:
+
+- `storeName: string` - the name of the parameter store to get
+
+Returns `ParameterStore`:
+
+- `isLoading: boolean;` - the loading/initializing state of the SDK
+- `store: ParameterStore` - the backing `ParameterStore` object
+
+**Example Usage:**
+
+```tsx
+import { useParameterStore } from '@statsig/react-native-bindings';
+
+function MyComponent() {
+  const store = useParameterStore('my_parameter_store');
+  
+  // Get parameters with fallback values - exposure logged here
+  const title = store.get('page_title', 'Default Title');
+  const maxItems = store.get('max_items', 10);
+  const isEnabled = store.get('feature_enabled', false);
+  
+  return <Text>{title}</Text>;
+}
+```
+
+:::note
+Exposures are logged when calling `.get()` on parameters, not when the hook is called.
+:::
+
+### `useStatsigUser`
+
+A react hook that provides access to the current StatsigUser and methods for updating user properties.
+
+Returns `UseStatsigUserResult`:
+
+- `user: StatsigUser` - the current user object
+- `updateUserSync: (user: StatsigUser) => StatsigUpdateDetails` - synchronously update the user
+- `updateUserAsync: (user: StatsigUser) => Promise<StatsigUpdateDetails>` - asynchronously update the user and fetch new values
+
+**Example Usage:**
+
+```tsx
+import { useStatsigUser } from '@statsig/react-native-bindings';
+
+function LoginComponent() {
+  const { user, updateUserAsync } = useStatsigUser();
+  
+  const handleLogin = async () => {
+    await updateUserAsync({ 
+      userID: "user123",
+      email: "user@example.com" 
+    });
+  };
+  
+  return (
+    <Button onPress={handleLogin} title="Login" />
+  );
+}
+```
+
+### `useStatsigClient`
+
+A react hook to access the StatsigClient instance directly for advanced usage.
+
+Returns `UseStatsigClientResult`:
+
+- `client: StatsigClient` - the StatsigClient instance
+- `isLoading: boolean` - whether the client is still initializing
+- `checkGate: (gateName: string) => boolean` - check a gate (logs exposure when called)
+- `getDynamicConfig: (configName: string) => DynamicConfig` - get a config (logs exposure when called)
+- `getExperiment: (experimentName: string) => DynamicConfig` - get an experiment (logs exposure when called)
+- `getLayer: (layerName: string) => Layer` - get a layer
+- `logEvent: (eventName: string, value?: string | number, metadata?: Record<string, string>) => void` - log an event
+
+**Example Usage:**
+
+```tsx
+import { useStatsigClient } from '@statsig/react-native-bindings';
+
+function MyComponent() {
+  const { checkGate, logEvent } = useStatsigClient();
+  
+  const handleButtonClick = () => {
+    if (checkGate('new_button_design')) {
+      logEvent('button_clicked', 1, { variant: 'new' });
+      // Show new button design
+    } else {
+      logEvent('button_clicked', 1, { variant: 'old' });
+      // Show old button design
+    }
+  };
+  
+  return <Button onPress={handleButtonClick} title="Click Me" />;
+}
+```
 
 ### `useStatsigLogEffect`
 


### PR DESCRIPTION
## Description

Adds missing React hooks documentation to React Native SDK reference. The React Native SDK exports all React hooks via `export * from '@statsig/react-bindings'` but the documentation was incomplete, missing several key hooks that users need.

**Added hooks:**
- `useGateValue` - convenience hook for boolean gate values
- `useFeatureGate` - returns full FeatureGate object with metadata  
- `useDynamicConfig` - convenience hook for dynamic configs
- `useParameterStore` - for parameter store access with example
- `useStatsigUser` - for updating user properties (specifically mentioned in Slack request)
- `useStatsigClient` - for direct client access

Each hook includes proper parameter/return documentation, exposure logging notes where relevant, and React Native-appropriate code examples.

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Human Review Checklist

**Critical items to verify:**
- [ ] Import statements use correct package name (`@statsig/react-native-bindings`)
- [ ] Hook descriptions match actual React Native SDK behavior
- [ ] Code examples use proper React Native components (`Text`, `Button`)
- [ ] Exposure logging notes are accurate for React Native
- [ ] All exported React hooks are covered and none incorrectly included

**Context:** This addresses the Slack request from tore@statsig.com about missing React Native hooks documentation, specifically mentioning `useStatsigUser` hook.

## Questions?

Reach out to Brock or Tore on Slack!

---

**Link to Devin run:** https://app.devin.ai/sessions/f65ffe31039347cd8ec394cd72e121e4  
**Requested by:** @tore-statsig