### PR TITLE
migrated ask ai to discover button, default to search

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -43,7 +43,9 @@ const config: Config = {
   plugins: [
     function statsig() {
       const isProd = process.env.NODE_ENV === "production";
-      const isNetlifyPreview = process.env.CONTEXT === "deploy-preview" || process.env.CONTEXT === "branch-deploy";
+      const isNetlifyPreview =
+        process.env.CONTEXT === "deploy-preview" ||
+        process.env.CONTEXT === "branch-deploy";
       const tier = isProd && !isNetlifyPreview ? "production" : "development";
       return {
         name: "docusaurus-plugin-statsig",
@@ -152,7 +154,17 @@ const config: Config = {
           },
           {
             to: "/feature-flags/overview",
-            from: ["/feature-gates/overview", "/feature-gates", "/feature-flags", "/feature-gates/working-with", "/feature-flags/working-with", "/feature-gates/implement", "/feature-gates/implement/client", "/feature-gates/implement/server", "/feature-gates/implement/http-api"],
+            from: [
+              "/feature-gates/overview",
+              "/feature-gates",
+              "/feature-flags",
+              "/feature-gates/working-with",
+              "/feature-flags/working-with",
+              "/feature-gates/implement",
+              "/feature-gates/implement/client",
+              "/feature-gates/implement/server",
+              "/feature-gates/implement/http-api",
+            ],
           },
           {
             to: "/feature-flags/create",
@@ -196,7 +208,13 @@ const config: Config = {
           },
           {
             to: "/",
-            from: ["/feature-flags/implement", "/feature-flags/implement/client", "/feature-flags/implement/server", "/feature-flags/implement/http-api", "/category/walkthrough-guides"],
+            from: [
+              "/feature-flags/implement",
+              "/feature-flags/implement/client",
+              "/feature-flags/implement/server",
+              "/feature-flags/implement/http-api",
+              "/category/walkthrough-guides",
+            ],
           },
           {
             to: "/pulse/read-pulse",
@@ -232,7 +250,12 @@ const config: Config = {
           },
           {
             to: "/product-analytics/overview",
-            from: ["/product-analytics", "/mex", "/mex/overview", "/metrics/events-explorer"],
+            from: [
+              "/product-analytics",
+              "/mex",
+              "/mex/overview",
+              "/metrics/events-explorer",
+            ],
           },
           {
             to: "/product-analytics/drilldown",
@@ -256,7 +279,10 @@ const config: Config = {
           },
           {
             to: "/client/javascript-sdk",
-            from: ["/client/introduction/javascript-sdk","/client/jsClientSDK"],
+            from: [
+              "/client/introduction/javascript-sdk",
+              "/client/jsClientSDK",
+            ],
           },
           {
             to: "/client/javascript-sdk/react",
@@ -272,7 +298,12 @@ const config: Config = {
           },
           {
             to: "/client/javascript-sdk/next-js",
-            from: ["/guides/nextjs-feature-flags", "/client/javascript-sdk/next-js-pages-router", "/guides/nextjs-page-router-feature-flags", "/client/javascript-sdk/next-js-app-router"],
+            from: [
+              "/guides/nextjs-feature-flags",
+              "/client/javascript-sdk/next-js-pages-router",
+              "/guides/nextjs-page-router-feature-flags",
+              "/client/javascript-sdk/next-js-app-router",
+            ],
           },
           {
             to: "/client/javascript-sdk/migrating-from-statsig-js",
@@ -288,7 +319,10 @@ const config: Config = {
           },
           {
             to: "/client/concepts/initialize",
-            from: ["/client/javascript-sdk/react/init-strategies", "/client/concepts/bootstrapping"],
+            from: [
+              "/client/javascript-sdk/react/init-strategies",
+              "/client/concepts/bootstrapping",
+            ],
           },
           {
             to: "/concepts/user",
@@ -522,21 +556,25 @@ const config: Config = {
       "data-website-id": "418990dd-0615-4ba7-b52f-3ab8c1af4e79",
       "data-project-name": "Statsig",
       "data-project-color": "#1963d2",
-      "data-project-logo": "https://statsig.com/images/sections/multi-products-v2/menu-statsig.svg",
+      "data-project-logo":
+        "https://statsig.com/images/sections/multi-products-v2/menu-statsig.svg",
       "data-scale-factor": "1.2",
       "data-modal-lock-scroll": "false",
-      "data-modal-image": "https://raw.githubusercontent.com/statsig-io/docs/f263b88116852d7c7174b82df1b528609a1ea073/static/img/favicon.svg",
+      "data-modal-image":
+        "https://raw.githubusercontent.com/statsig-io/docs/f263b88116852d7c7174b82df1b528609a1ea073/static/img/favicon.svg",
       "data-button-hide": "true",
       "data-modal-override-open-id": "ask-ai-navbar-button",
-      "data-modal-override-open-id-ask-ai": "ask-ai-navbar-button",
-      "data-modal-disclaimer": "Statsig Docs AI answers questions using documentations, API references, blogs, and videos. Responses are AI-generated, and we encourage you to rate them to let us know what you think!",
-      "data-answer-feedback-info-text": "All feedback is reviewed by the Statsig team.",
+      "data-modal-disclaimer":
+        "Statsig Docs AI answers questions using documentations, API references, blogs, and videos. Responses are AI-generated, and we encourage you to rate them to let us know what you think!",
+      "data-answer-feedback-info-text":
+        "All feedback is reviewed by the Statsig team.",
+      "data-search-mode-default": "true",
       "data-search-mode-enabled": "true",
       "data-modal-open-on-command-k": "true",
       "data-modal-command-k-search-mode-default": "true",
       "data-modal-search-input-placeholder": "Search Statsig docs...",
       "data-search-include-source-names": '["Documentation"]',
-      "data-search-show-ask-ai-cta": "false",
+      "data-search-show-ask-ai-cta": "true",
       "data-search-result-link-target": "_self",
       "data-modal-full-screen-on-mobile": "false",
       "data-kapa-branding-text": "Powered by kapa.ai and Statsig",

--- a/src/components/NavbarItems/AskAI/index.js
+++ b/src/components/NavbarItems/AskAI/index.js
@@ -1,8 +1,9 @@
 import React, { useCallback } from "react";
 
 const ASK_AI_BUTTON_ID = "ask-ai-navbar-button";
-const ASK_AI_LABEL = "Ask AI";
-const ASK_AI_ICON_SRC = "https://statsig.com/images/sections/multi-products-v2/menu-statsig.svg";
+const ASK_AI_LABEL = "Discover";
+const ASK_AI_ICON_SRC =
+  "https://statsig.com/images/sections/multi-products-v2/menu-statsig.svg";
 const KAPA_SCRIPT_ID = "kapa-widget-script";
 
 const openKapaWidget = () => {
@@ -10,7 +11,7 @@ const openKapaWidget = () => {
     return false;
   }
 
-  const opener = window.Kapa?.open;
+  const opener = window.Kapa?.open({ mode: "search" });
   if (typeof opener === "function") {
     opener.call(window.Kapa);
     return true;
@@ -55,7 +56,12 @@ const AskAI = () => {
         type="button"
         onClick={handleClick}
       >
-        <img className="ask-ai-button__icon" src={ASK_AI_ICON_SRC} alt="" aria-hidden="true" />
+        <img
+          className="ask-ai-button__icon"
+          src={ASK_AI_ICON_SRC}
+          alt=""
+          aria-hidden="true"
+        />
         <span className="ask-ai-button__label">{ASK_AI_LABEL}</span>
       </button>
     </div>


### PR DESCRIPTION
## Description

Some people we're confused that Ask AI took over the search bar, so renamed Ask AI to discover, have it default to search, and enabled the data search show ask ai option so its still there if individuals want it. The Cmd + K integration is still there as well

<img width="2672" height="1469" alt="image" src="https://github.com/user-attachments/assets/67b8edc3-fa88-475b-8453-e980d3f88583" />

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [x] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!