### PR TITLE
The alerts tab is now the overview (no indepedent overview page under…

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -427,11 +427,14 @@ const sidebars: SidebarsConfig = {
             {
               type: "category",
               label: "Alerts",
+              link: {
+                type: "doc",
+                id: "product-analytics/alerts",
+              },
               items: [
-                "product-analytics/alerts",
                 "product-analytics/rollout_alerts",
                 "product-analytics/topline_alerts",
-              ],
+              ],            
             },
           ],
         },


### PR DESCRIPTION
Moved the alerts overview page to be the "Topline Alerts" tab itself. 

## Description

Brief summary or screenshot of your changes

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!