### PR TITLE
Adding note that WHN is enterprise only

### DIFF
--- a/docs/statsig-warehouse-native/guides/connect.md
+++ b/docs/statsig-warehouse-native/guides/connect.md
@@ -8,6 +8,10 @@ last_update:
   date: 2025-09-18
 ---
 
+:::info Note
+Warehouse Native is part of Statsig's Enterprise tier. Please [contact us to learn more](https://statsig.com/pricing)
+:::
+
 To run analysis on your warehouse, Statsig needs to connect to your warehouse via a service user. You control the access this user gets to your warehouse. In general, Statsig will require:
 
 - Read access to metric data and exposures data

--- a/docs/statsig-warehouse-native/introduction.mdx
+++ b/docs/statsig-warehouse-native/introduction.mdx
@@ -40,6 +40,10 @@ export const ArrowButton = ({ link }) => (
   </IconButton>
 );
 
+:::info Note
+Warehouse Native is part of Statsig's Enterprise tier. Please [contact us to learn more](https://statsig.com/pricing)
+:::
+
 Statsig Warehouse Native is an enterprise-grade experimentation platform that runs analysis in your data warehouse. It integrates easily with your existing datasets and any source of experiment assignment data – including a powerful integration with Statsig's SDKs and real-time logging infrastructure.
 
 Warehouse Native shares core features with Statsig Cloud but focuses on specific scenarios around running experiments on top of your warehouse.


### PR DESCRIPTION
## Description

Brief summary or screenshot of your changes
Adding a Info banner on two WHN introduction pages to inform the user that WHN is enterprise only. I had someone on the support slack miss this from looking at the docs.

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock or Tore on Slack!