### PR TITLE
Corrected link to Statsig server core .NET NuGet package

### DIFF
--- a/server-core/dotnet-core.mdx
+++ b/server-core/dotnet-core.mdx
@@ -44,7 +44,7 @@ import notes from '/snippets/server-core/dotnet/notes.mdx'
 
 <Callout icon="github">
 <a href="https://github.com/statsig-io/statsig-server-core/tree/main/statsig-ffi/bindings/dotnet" target="_blank" rel="noreferrer">.NET Core on Github</a>, 
-<a href="https://www.nuget.org/packages/Statsig.Server.Core/" target="_blank" rel="noreferrer">NuGet Package</a>
+<a href="https://www.nuget.org/packages/Statsig.Dotnet/" target="_blank" rel="noreferrer">NuGet Package</a>
 </Callout>
 
 ## Setup the SDK


### PR DESCRIPTION
## Description
Corrected link to Statsig server core .NET NuGet package that was going to a 404

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, Tore, or Logan on Slack!
