### PR TITLE
iOS docs: updateUserWithResult, eventLoggingEnabled caching

### DIFF
--- a/client/iosClientSDK.mdx
+++ b/client/iosClientSDK.mdx
@@ -12,7 +12,6 @@ import getDynamicConfigIntro from '/snippets/client/getDynamicConfig.mdx'
 import getExperimentLayerIntro from '/snippets/client/getExperimentLayer.mdx'
 import logEventIntro from '/snippets/client/logEvent.mdx'
 import paramStores from '/snippets/client/paramStores.mdx'
-import statsigUserIntro from '/snippets/client/statsigUser.mdx'
 import statsigOptionsIntro from '/snippets/client/statsigOptions.mdx'
 import manualExposures from '/snippets/client/manualExposures.mdx'
 import iosManualExposures from '/snippets/client/iOS/manualExposures.mdx'
@@ -64,7 +63,6 @@ import iosListening from '/snippets/client/iOS/listening.mdx'
 
 <paramStores />
 
-<statsigUserIntro />
 <iosStatsigUser />
 
 <statsigOptionsIntro />

--- a/snippets/client/iOS/statsigOptions.mdx
+++ b/snippets/client/iOS/statsigOptions.mdx
@@ -85,7 +85,7 @@
 </ResponseField>
 
 <ResponseField name="eventLoggingEnabled" type="Bool" default="true">
-  Controls whether the SDK sends events over the network. Useful when user consent is needed before sending events.
+  Controls whether the SDK sends events over the network. Useful when user consent is needed before sending events. The iOS SDK stores up to 1MB of unsent request payloads
 </ResponseField>
 
 <ResponseField name="initializeValues" type="[String: Any]" default="nil">

--- a/snippets/client/iOS/statsigUser.mdx
+++ b/snippets/client/iOS/statsigUser.mdx
@@ -1,3 +1,18 @@
+## Statsig User
+
+You need to provide a StatsigUser object to check/get your configurations. You should pass as much 
+information as possible in order to take advantage of advanced gate and config conditions.
+
+Most of the time, the `userID` field is needed in order to provide a consistent experience for a given 
+user (see [logged-out experiments](/guides/first-device-level-experiment) to understand how to correctly run experiments for logged-out 
+users). 
+
+Besides `userID`, we also have `email`, `ip`, `userAgent`, `country`, `locale` and `appVersion` as top-level fields on 
+StatsigUser. In addition, you can pass any key-value pairs in an object/dictionary to the `custom` field and be able to 
+create targeting based on them.
+
+Once the user logs in or has an update/changed, make sure to call `updateUserWithResult`
+with the updated `userID` and/or any other updated user attributes:
 
 <CodeGroup>
 ```swift Swift


### PR DESCRIPTION
## Description
Updated iOS SDK docs: 
- updateUser has been depreciated and replaced with updateUserWithResult
- eventLoggingEnabled caches 1MB of events when disabled

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, Tore, or Logan on Slack!
