### PR TITLE
Added INP (Interaction to Next Paint) core web vitals metric

### DIFF
--- a/webanalytics/overview.mdx
+++ b/webanalytics/overview.mdx
@@ -184,7 +184,7 @@ const client = new StatsigClient(
 
 Statsig automatically captures Core Web Vitals metrics that are essential for measuring user experience and SEO performance:
 
-### The Four Core Web Vitals
+### Core Web Vitals Metrics
 
 - **CLS (Cumulative Layout Shift)** - Measures visual stability by tracking unexpected layout shifts during page load. Lower scores indicate better user experience.
 
@@ -193,6 +193,8 @@ Statsig automatically captures Core Web Vitals metrics that are essential for me
 - **LCP (Largest Contentful Paint)** - Measures loading performance by tracking when the largest content element becomes visible. This metric correlates strongly with user-perceived load times.
 
 - **TTFB (Time to First Byte)** - Measures server response time by tracking how long it takes to receive the first byte of response from the server. This indicates server and network performance.
+
+- **INP (Interaction to Next Paint)** - Measures responsiveness by tracking the longest latency across user interactions. Lower values mean more consistent, responsive experiences.
 
 These metrics are automatically collected and sent as `auto_capture::web_vitals` events, providing insights into your website's performance and user experience quality.
 
@@ -236,4 +238,3 @@ The autocapture plugin or manual setup can take an optional `options` parameter 
 **eventFilterFunc**:
 - **`event`**: `AutoCaptureEvent` - The event object that is being captured.
 - **`return`**: `bool` - A boolean to return true to capture the event or false to ignore it.
-


### PR DESCRIPTION
## Description

Added INP (Interaction to Next Paint) core web vitals metric to web analytics overview page

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, Tore, or Logan on Slack!
