### PR TITLE
ID resolution clarification

### DIFF
--- a/statsig-warehouse-native/features/id-resolution.mdx
+++ b/statsig-warehouse-native/features/id-resolution.mdx
@@ -194,4 +194,4 @@ Deduplicating records can lead to biased results, so Statsig preforms two extra 
   using different devices or clearing browser history
 - Statsig will perform a chi-squared test evaluating if the deduplication rate is identical across arms of the experiment. In some cases, an experiment may cause more users to come back (for example an email resurrection campaign), in which case duplicates are expected to be more frequent in that arm and can be a positive outcome. In this case, you can perform first-touch attribution to maintain a common identifier
 
-Breakdowns of metric dimensions for experiment results is only supported on properties associated with primary ID types. Secondary ID type dimension breakdown for experiment results and custom queries is currently not supported.
+Breakdowns of metric dimensions for experiment results is only supported on properties associated with primary ID types. Secondary ID type dimension breakdown for experiment results and custom queries is currently not supported due to high risk of post-exposure data leaking into the group-by's or filters.


### PR DESCRIPTION
Common questions about ID stitching and breakdowns on secondary metrics - we don't support metric dimension breakdowns in experiment results for secondary ID types. Adding this clarification to docs

## Description

[Include a brief summary or screenshot of your changes]

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, Tore, or Logan on Slack!
