### PR TITLE
Update renaming policy for experiments and gates

### DIFF
--- a/faq.mdx
+++ b/faq.mdx
@@ -19,8 +19,7 @@ No. Layers are fixed once an experiment starts to preserve the integrity of resu
 
 ### Can I rename an experiment or gate after creating it?
 
-No. Renaming configs that are already referenced in code risks breaking user experiences. If you need a new name, create a new config. (Metrics are the exception—they have display names only.)
-
+You can rename an experiment or gate after it’s created. However, only the display name can be changed - the ID (which is referenced in your code) remains fixed to prevent breaking existing implementation. Note: Metrics are an exception since they use display names only.
 ---
 
 ### Why define parameters instead of just reading the experiment group?


### PR DESCRIPTION
Clarified the ability to rename experiments or gates, specifying that only the display name can be changed while the ID remains fixed.

## Description

[Include a brief summary or screenshot of your changes]

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, Tore, or Logan on Slack!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies that experiments and gates can be renamed by changing the display name only; IDs remain fixed, with metrics as a display-name-only exception.
> 
> - **Docs**:
>   - Update `faq.mdx` renaming guidance: experiments/gates can have their display names changed while IDs remain fixed; note metrics use display names only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b73227c0515ae357fd4c3d57d1bae3cd27aaf58b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->