### PR TITLE
Fixed typo in setting-up-reviews guide

### DIFF
--- a/guides/setting-up-reviews.mdx
+++ b/guides/setting-up-reviews.mdx
@@ -44,7 +44,7 @@ You can now use these predefined **Teams** when you submit any changes for revie
 </Frame>
 
 ### Enforcing Team Reviews
-You can _a priori_ restrict who can make changes to your Project by (a) turning on **Reviews Required** for your Project and (b) adding designated **Teams** or **Reviewers** when you create the Feature Gate or Experiment. 
+You can restrict who can make changes to your Project by (a) turning on **Reviews Required** for your Project and (b) adding designated **Teams** or **Reviewers** when you create the Feature Gate or Experiment. 
 
 For (a), see section **Turning on Change Reviews for a Project** to turn on project-wide reviews. For (b), as an owner of a Feature Gate or Experiment, you can add designated **Teams** or **Reviewers** at any time as shown below. This ensures that only these designated groups or members can review and approve any subsequent changes. When another member now tries to edit these designated review groups/reviewers, this will require approval from currently designated reviewers. 
 


### PR DESCRIPTION
## Description
Fixed typo in setting-up-reviews guide

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, Tore, or Logan on Slack!
