### PR TITLE
EE-1864 add notes on experiment archival

### DIFF
--- a/experiments/ending/ending-experiment.mdx
+++ b/experiments/ending/ending-experiment.mdx
@@ -13,6 +13,13 @@ To ship any of the groups in your experiment, including control, to all your use
 ## Stopping an Experiment
 If your experiment has a problem and you need to stop it, there are two routes you can take.
 - If the problem means you no longer wish to run this test, you can [Abandon the experiment](/experiments-plus/abandon). This will put the experiment in a finished state, and all users will fall back to defaults in code. You can still Reset this later, if you decide to revisit the experiment.
-- If one of the groups has a bug you plan to fix, and you wish to later restart the experiment, you can Reset the experiment.
+- If one of the groups has a bug you plan to fix, and you wish to later restart the experiment, you can Reset the experiment. Alternatively, you can [disable a group](https://docs.statsig.com/experiments/implementation/disable-group) with bug if you intend to keep the other test groups in experiment running.
 
-Resetting will put the experiment into an unstarted state. Every user will get the default experience - either the value defined in code or the layer default. Additionally, the "salt" used to randomize a user's group will be changed. This means that when you start the experiment again, your users will be randomly assigned to a group that is not necessarily the same group they were in prior to the experiment being reset. This is important because it makes sure that the new result for the group that was not performing well due to an issue like a bug or bad experience in the previous run, is not negatively affected even after the issue is addressed in the new version.
+Resetting will put the experiment into an unstarted state. Every user will get the default experience - either the value defined in code or the layer default. Additionally, the "salt" used to randomize a user's group will be changed. This means that when you start the experiment again, your users will be randomly assigned to a group that is not necessarily the same group they were in prior to the experiment being reset.
+
+This is important because it makes sure that the new result for the group that was not performing well due to an issue like a bug or bad experience in the previous run, is not negatively affected even after the issue is addressed in the new version.
+
+## Archiving an Experiment
+After an experiment’s decision has been made, or when it is abandoned or reset, you can archive the experiment. Archiving preserves the experiment’s history and results, and makes the experiment as read-only.
+
+If you later decide to make the experiment active again, you can unarchive the experiment and make it editable. Note that unarchiving does not automatically restart the experiment. If the experiment was previously part of a layer and you intend to include it again, you’ll need to manually reallocate it to that layer.


### PR DESCRIPTION
## Description

https://linear.app/statsig/issue/EE-1864/docs-adding-a-section-on-archiving-experiment

EE-1864

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, Tore, or Logan on Slack!
