### PR TITLE
Clarify metric descriptions in metric-drill-down.mdx

### DIFF
--- a/snippets/pulse/metric-drill-down.mdx
+++ b/snippets/pulse/metric-drill-down.mdx
@@ -44,13 +44,13 @@ In this view, select and drag as needed to zoom-in on different time ranges.  Th
   <img src="https://github.com/user-attachments/assets/f42453a6-e413-47d5-b176-bb3e9b49a915" alt="Daily metric impact visualization interface" />
 </Frame>
 
-**Cumulative**: Shows how the aggregated metric lift and confidence intervals evolve over time. 
+**Cumulative**: Shows the cumulative metric impact from the start of experiment over time.  This is a good way to observe trends and see how your confidence interval changes over time.
 
 <Frame>
   <img src="https://github.com/user-attachments/assets/b2e9aea9-98fb-4e29-bccf-abae356d0173" alt="Cumulative metric lift visualization interface" />
 </Frame>
  
-**Days Since Exposure**: Shows the metric impact broken down by the number of days users have been in the experiment, which helps distinguish between novelty effects and sustained impact.  For key metrics, this view also shows pre-experiment metrics to identify an differences that existed between groups even before the experiment started.  
+**Days Since Exposure**: Shows the metric impact based on how long a user has been in the experiment.  Daily data for each user is aligned by the day they entered the experiment (Day 0, Day 1, ...etc), not by calendar date.  This allows you to distinguish early (novelty) from long-term effects.  This view also shows pre-experiment data which identifies biases between groups before the experiment started.  This can happen due to random chance or by some issue in the random assignment process.
 
 <Frame>
   <img src="https://github.com/user-attachments/assets/17eeb054-43d8-424c-b43a-85c682bfcfb8" alt="Days since exposure metric visualization interface" />


### PR DESCRIPTION
Updated descriptions for Cumulative and Days Since Exposure metrics to clarify their meanings and implications.

## Description

I improved explaination of daily/cumulative/days since exposure views.

## Best practice checklist

- [Y] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, Tore, or Logan on Slack!
