### PR TITLE
Fixing link to Java server core repo in Github

### DIFF
--- a/server-core/java-core.mdx
+++ b/server-core/java-core.mdx
@@ -51,7 +51,7 @@ import reference from '/snippets/server-core/java/reference.mdx'
 import quickStart from '/snippets/server-core/java/quickStart.mdx'
 
 <Callout icon="github">
-<a href="https://github.com/statsig-io/statsig-server-core/tree/main/statsig-ffi/bindings/java" target="_blank" rel="noreferrer">Java Core on Github</a>
+<a href="https://github.com/statsig-io/statsig-server-core/tree/main/statsig-java" target="_blank" rel="noreferrer">Java Core on Github</a>
 </Callout>
 
 <Tip>Migrating from the Legacy Java SDK? See our [Migration Guide](/server-core/migration-guides/java).</Tip>


### PR DESCRIPTION
## Description

Fixing link on Java server core docs page to its repo in Github

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, Tore, or Logan on Slack!
