### PR TITLE
safeguard remove beta

### DIFF
--- a/feature-flags/safeguards-overview.mdx
+++ b/feature-flags/safeguards-overview.mdx
@@ -6,7 +6,7 @@ description: "Ship with confidence by automatically monitoring critical metrics 
 Safeguards help you ship with confidence by continuously monitoring critical metrics and automatically intervening in your Feature Gate rollouts when risk thresholds are exceeded. This ensures faster recovery from issues, eliminates the need for constant manual checks, and protects your users from unintended impact.
 
 <Info>
-Safeguards is currently in open beta and is available on our Pro and Enterprise billing tiers. Please reach out to us if you have questions or feedback.
+Safeguards is available on our Pro and Enterprise billing tiers.
 </Info>
 
 ## When to use Safeguards


### PR DESCRIPTION
## Description

Updated the Safeguards information banner to reflect that it's no longer in open beta. Removed the beta status message and the request for questions/feedback.

## Best practice checklist

- [ ] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [ ] I've deleted and redirected old pages to this one, if any
- [ ] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, Tore, or Logan on Slack!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Safeguards overview to remove the open beta message, stating availability on Pro and Enterprise tiers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05c5dcbef7fc84f69554dfc4bcfbd79d30f55fb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->