### PR TITLE
Fix slash shortcut for kapa

### DIFF
--- a/edit-page.js
+++ b/edit-page.js
@@ -91,6 +91,7 @@
     '.DocSearch-Button',
     'button[class*="search"]',
   ];
+  const KAPA_WIDGET_SELECTOR = '#kapa-button,[id*="kapa"],[class*="kapa"],[data-kapa-button],[data-kapa-launcher],[data-kapa-widget]';
 
   function isEditableElement(element) {
     if (!element) {
@@ -103,6 +104,25 @@
       tagName === 'INPUT' ||
       tagName === 'TEXTAREA' ||
       element.getAttribute('role') === 'textbox'
+    );
+  }
+
+  function isKapaEvent(event) {
+    const path = typeof event.composedPath === 'function'
+      ? event.composedPath()
+      : [event.target];
+
+    return (
+      path.some(function(element) {
+        return (
+          element instanceof Element &&
+          Boolean(element.closest(KAPA_WIDGET_SELECTOR))
+        );
+      }) ||
+      Boolean(
+        document.activeElement &&
+        document.activeElement.closest(KAPA_WIDGET_SELECTOR)
+      )
     );
   }
 
@@ -138,7 +158,8 @@
         event.metaKey ||
         event.ctrlKey ||
         event.shiftKey ||
-        isEditableElement(event.target)
+        isEditableElement(event.target) ||
+        isKapaEvent(event)
       ) {
         return;
       }


### PR DESCRIPTION
## Description

Fix the slash shortcut behavior for Ask AI widget.

<img width="1461" height="727" alt="Screenshot 2026-04-24 at 4 28 04 PM" src="https://github.com/user-attachments/assets/9f2a82f1-7eda-4ca5-87e8-00747034bcc9" />


## Best practice checklist

- [v] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [v] I've deleted and redirected old pages to this one, if any
- [v] I've updated links affected by this change, if any
- [v] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, T̶o̶r̶e̶,̶ or Logan on Slack!
