### PR TITLE
Fix broken internal links in contextual bandit introduction

### DIFF
--- a/autotune/contextual/introduction.mdx
+++ b/autotune/contextual/introduction.mdx
@@ -32,10 +32,10 @@ There is support for specifying features up front in Statsig's console. This can
 
 Algorithmically, we will choose the best model (e.g. Ridge, Logistic regressions) under the hood based on your data types and performance, and generate a model from your data. The estimated standard error of the model is used to generate a prediction confidence interval. During evaluation, user context is used to predict an outcome for each Variant, and the corresponding confidence interval is applied to that prediction. The best variant is chosen as the one with the highest upper end of a 95% confidence interval. This interval size can be tuned by modifying the exploration parameter in the Autotune setup page.
 
-For deeper discussion, please view the [Methodology](./methodology.md) page.
+For deeper discussion, refer to the [Methodology](/autotune/contextual/methodology) page.
 
 <Note>
-You can also fetch a ranked list from Statsig and then manually expose those you show to the user, for use cases where you have client-side filtering or want to show multiple options; see [Advanced Usage](../using-bandits.md)
+You can also fetch a ranked list from Statsig and then manually expose those you show to the user, for use cases where you have client-side filtering or want to show multiple options; refer to [Advanced Usage](/autotune/using-bandits).
 </Note>
 
 ## Drawbacks

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+    "scripts": {
+        "setup": "npm i -g mintlify",
+        "remoteSetup": "npm i -g mintlify",
+        "run": "mintlify dev"
+    }
+}


### PR DESCRIPTION
## Description

Fixes two broken internal links in the contextual bandit introduction page (`autotune/contextual/introduction.mdx`):

- The "Methodology" link pointed to `./methodology.md` (a raw Markdown file path) instead of the rendered docs page. Fixed to `/autotune/contextual/methodology`.
- The "Advanced Usage" link in the same Note callout had the same issue (`../using-bandits.md`). Fixed to `/autotune/using-bandits`.

Both links now use root-relative paths with no file extension, per repo conventions. Resolves DOC-117.

## Best practice checklist

- [x] I've considered the best practices on [where to put your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d80f7b1f0e14e93af4eb5) and [what to put in your doc](https://www.notion.so/statsig/Statsig-Docs-Contribution-Guide-1c4d27b5090d8093856ff2d94f170a9c?pvs=4#1c4d27b5090d805bb4d0d6b4b8f06fa6)
- [x] I've deleted and redirected old pages to this one, if any
- [x] I've updated links affected by this change, if any
- [ ] I've updated screenshots affected by this change, if any

## Questions?

Reach out to Brock, T̶o̶r̶e̶,̶ or Logan on Slack!